### PR TITLE
Vec constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+**v2.6.4** Vec2D and Vec3D now support `copy` constructor where the original can be a duck-type. Further the only requirement is that the duck-type responds to `:x`, and `:y` by returning a `float` or `fixnum` thus Vec2D can be promoted to Vec3D (where `z = 0`), or more usually some other Vector or Point class can be used as the original. A VectorUtils library has been implemented, see examples for usage.
+
 **v2.6.3** Bump recommended upgrade to jruby-9.1.15.0, possibly the last in 9.1 series?
 
 **v2.6.2** Features example sketches using the PixelFlow library by Thomas Diewald

--- a/lib/propane/version.rb
+++ b/lib/propane/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Propane
-  VERSION = '2.6.3'.freeze
+  VERSION = '2.6.4'.freeze
 end

--- a/library/vector_utils/vector_utils.rb
+++ b/library/vector_utils/vector_utils.rb
@@ -1,0 +1,69 @@
+PHI ||= (1 + Math.sqrt(5)) / 2 # golden ratio
+GA = PHI * 2 * Math::PI # golden angle
+
+# Useful Vector Utiliies
+module VectorUtil
+  def self.rotate_vec2d(vectors: [], angle: 0)
+    vectors.map { |vector| vector.rotate(angle) }
+  end
+
+  def self.vogel_layout(number:, node_size:)
+    (0..number).map do |i|
+      r = Math.sqrt(i)
+      theta = i * ((2 * Math::PI) / (PHI * PHI))
+      x = Math.cos(theta) * r * node_size
+      y = Math.sin(theta) * r * node_size
+      Vec2D.new(x, y)
+    end
+  end
+
+  def self.fibonacci_sphere(number:, radius:)
+    (0..number).map do |i|
+      lon = GA * i
+      lon /= 2 * Math::PI
+      lon -= lon.floor
+      lon *= 2 * Math::PI
+      lon -= 2 * Math::PI if lon > Math::PI
+      lat = Math.asin(-1 + 2 * i / number.to_f)
+      x = radius * Math.cos(lat) * Math.cos(lon)
+      y = radius * Math.cos(lat) * Math.sin(lon)
+      z = radius * Math.sin(lat)
+      Vec3D.new(x, y, z)
+    end
+  end
+
+  def self.spiral_layout(number:, radius:, resolution:, spacing:, inc:)
+    n = 0
+    angle = nil
+    (0..number).map do
+      angle = n * resolution
+      n += inc
+      radius -= angle * spacing
+      x = Math.cos(angle) * radius
+      y = Math.sin(angle) * radius
+      Vec2D.new(x, y)
+    end
+  end
+
+  def self.cartesian_to_polar(vec:)
+    res = Vec3D.new(vec.mag, 0, 0)
+    return Vec3D.new unless res.x > 0
+    res.y = -Math.atan2(vec.z, vec.x)
+    res.z = Math.asin(vec.y / res.x)
+    res
+  end
+
+  def self.to_cartesian(lat:, long:, radius:)
+    latitude = lat
+    longitude = long
+    x = radius * Math.cos(latitude) * Math.cos(longitude)
+    y = radius * Math.cos(latitude) * Math.sin(longitude)
+    z = radius * Math.sin(latitude)
+    Vec3D.new(x, y, z)
+  end
+
+  def self.polar_to_cartesian(vec:)
+    return Vec3D.new if vec.mag <= 0
+    Vec3D.new(Math.asin(vec.y / vec.mag), vec.mag, -Math.atan2(vec.z, vec.x))
+  end
+end

--- a/pom.rb
+++ b/pom.rb
@@ -1,7 +1,7 @@
 require 'fileutils'
 project 'rp5extras', 'https://github.com/monkstone/propane' do
   model_version '4.0.0'
-  id 'propane:propane', '2.6.3'
+  id 'propane:propane', '2.6.4'
   packaging 'jar'
   description 'rp5extras for propane'
   organization 'ruby-processing', 'https://ruby-processing.github.io'

--- a/src/monkstone/vecmath/vec2/Vec2.java
+++ b/src/monkstone/vecmath/vec2/Vec2.java
@@ -1,20 +1,20 @@
 package monkstone.vecmath.vec2;
 
-/* 
+/*
 * Copyright (c) 2015-17 Martin Prout
-* 
+*
 * This library is free software; you can redistribute it and/or
 * modify it under the terms of the GNU Lesser General Public
 * License as published by the Free Software Foundation; either
 * version 2.1 of the License, or (at your option) any later version.
-* 
+*
 * http://creativecommons.org/licenses/LGPL/2.1/
-* 
+*
 * This library is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 * Lesser General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU Lesser General Public
 * License along with this library; if not, write to the Free Software
 * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
@@ -88,11 +88,16 @@ public class Vec2 extends RubyObject {
     }
 
     void init(ThreadContext context, IRubyObject[] args) {
-        if (Arity.checkArgumentCount(context.runtime, args, Arity.OPTIONAL.getValue(), 2) == 2) {
-            jx = (args[0] instanceof RubyFloat)
-                    ? ((RubyFloat) args[0]).getValue() : ((RubyFixnum) args[0]).getDoubleValue();
-            jy = (args[1] instanceof RubyFloat)
-                    ? ((RubyFloat) args[1]).getValue() : ((RubyFixnum) args[1]).getDoubleValue();
+        int count = Arity.checkArgumentCount(context.runtime, args, Arity.OPTIONAL.getValue(), 2);
+        if (count == 2) {
+            jx = (args[0] instanceof RubyFloat) ? ((RubyFloat) args[0]).getValue() : ((RubyFixnum) args[0]).getDoubleValue();
+            jy = (args[1] instanceof RubyFloat) ? ((RubyFloat) args[1]).getValue() : ((RubyFixnum) args[1]).getDoubleValue();
+        }   // allow ruby ducktyping in constructor
+        if (count == 1) {
+            jx = ((args[0].callMethod(context, "x")) instanceof RubyFloat)
+                    ? ((RubyFloat) args[0].callMethod(context, "x")).getValue() : ((RubyFixnum) args[0].callMethod(context, "x")).getDoubleValue();
+            jy = ((args[0].callMethod(context, "y")) instanceof RubyFloat)
+                    ? ((RubyFloat) args[0].callMethod(context, "y")).getValue() : ((RubyFixnum) args[0].callMethod(context, "y")).getDoubleValue();
         }
     }
 

--- a/src/monkstone/vecmath/vec2/Vec2.java
+++ b/src/monkstone/vecmath/vec2/Vec2.java
@@ -94,7 +94,7 @@ public class Vec2 extends RubyObject {
             jy = (args[1] instanceof RubyFloat) ? ((RubyFloat) args[1]).getValue() : ((RubyFixnum) args[1]).getDoubleValue();
         }   // allow ruby ducktyping in constructor
         if (count == 1) {
-            if (!(args[0].respondsTo("x"))) {throw context.runtime.newTypeError(args[0].getType() + " doesn't respond_to :x, :y");}
+            if (!(args[0].respondsTo("x"))) {throw context.runtime.newTypeError(args[0].getType() + " doesn't respond_to :x & :y");}
             jx = ((args[0].callMethod(context, "x")) instanceof RubyFloat)
                     ? ((RubyFloat) args[0].callMethod(context, "x")).getValue() : ((RubyFixnum) args[0].callMethod(context, "x")).getDoubleValue();
             jy = ((args[0].callMethod(context, "y")) instanceof RubyFloat)

--- a/src/monkstone/vecmath/vec2/Vec2.java
+++ b/src/monkstone/vecmath/vec2/Vec2.java
@@ -159,9 +159,11 @@ public class Vec2 extends RubyObject {
         Ruby runtime = context.runtime;
         if (key instanceof RubySymbol) {
             if (key == RubySymbol.newSymbol(runtime, "x")) {
-                return runtime.newFloat(jx);
+                jx = (value instanceof RubyFloat)
+                        ? ((RubyFloat) value).getValue() : ((RubyFixnum) value).getDoubleValue();
             } else if (key == RubySymbol.newSymbol(runtime, "y")) {
-                return runtime.newFloat(jy);
+                jy = (value instanceof RubyFloat)
+                        ? ((RubyFloat) value).getValue() : ((RubyFixnum) value).getDoubleValue();
             }
         } else {
             throw runtime.newIndexError("invalid key");

--- a/src/monkstone/vecmath/vec2/Vec2.java
+++ b/src/monkstone/vecmath/vec2/Vec2.java
@@ -94,7 +94,7 @@ public class Vec2 extends RubyObject {
             jy = (args[1] instanceof RubyFloat) ? ((RubyFloat) args[1]).getValue() : ((RubyFixnum) args[1]).getDoubleValue();
         }   // allow ruby ducktyping in constructor
         if (count == 1) {
-            if (!(args[0].respondsTo("x"))) {throw context.runtime.newTypeError("argument should respond_to :x, :y");}
+            if (!(args[0].respondsTo("x"))) {throw context.runtime.newTypeError(args[0].getType() + " doesn't respond_to :x, :y");}
             jx = ((args[0].callMethod(context, "x")) instanceof RubyFloat)
                     ? ((RubyFloat) args[0].callMethod(context, "x")).getValue() : ((RubyFixnum) args[0].callMethod(context, "x")).getDoubleValue();
             jy = ((args[0].callMethod(context, "y")) instanceof RubyFloat)

--- a/src/monkstone/vecmath/vec2/Vec2.java
+++ b/src/monkstone/vecmath/vec2/Vec2.java
@@ -94,6 +94,7 @@ public class Vec2 extends RubyObject {
             jy = (args[1] instanceof RubyFloat) ? ((RubyFloat) args[1]).getValue() : ((RubyFixnum) args[1]).getDoubleValue();
         }   // allow ruby ducktyping in constructor
         if (count == 1) {
+            if (!(args[0].respondsTo("x"))) {throw context.runtime.newTypeError("argument should respond_to :x, :y");}
             jx = ((args[0].callMethod(context, "x")) instanceof RubyFloat)
                     ? ((RubyFloat) args[0].callMethod(context, "x")).getValue() : ((RubyFixnum) args[0].callMethod(context, "x")).getDoubleValue();
             jy = ((args[0].callMethod(context, "y")) instanceof RubyFloat)

--- a/src/monkstone/vecmath/vec3/Vec3.java
+++ b/src/monkstone/vecmath/vec3/Vec3.java
@@ -94,653 +94,757 @@ public final class Vec3 extends RubyObject {
                     ? ((RubyFloat) args[2]).getValue() : ((RubyFixnum) args[2]).getDoubleValue();
         } // allow ruby ducktyping in constructor
         if (count == 1) {
+            if (!(args[0].respondsTo("x"))) {throw context.runtime.newTypeError("argument should respond_to :x, :y");}
             jx = ((args[0].callMethod(context, "x")) instanceof RubyFloat)
                     ? ((RubyFloat) args[0].callMethod(context, "x")).getValue() : ((RubyFixnum) args[0].callMethod(context, "x")).getDoubleValue();
             jy = ((args[0].callMethod(context, "y")) instanceof RubyFloat)
                     ? ((RubyFloat) args[0].callMethod(context, "y")).getValue() : ((RubyFixnum) args[0].callMethod(context, "y")).getDoubleValue();
-            jz = ((args[0].callMethod(context, "z")) instanceof RubyFloat)
-                    ? ((RubyFloat) args[0].callMethod(context, "z")).getValue() : ((RubyFixnum) args[0].callMethod(context, "z")).getDoubleValue();
+            if (!(args[0].respondsTo("z"))) {return;} // allow promotion from 2D to 3D, sets jz = 0
+            jz = ((args[0].callMethod(context, "z")) instanceof RubyFloat) ? ((RubyFloat) args[0].callMethod(context, "z")).getValue() : ((RubyFixnum) args[0].callMethod(context, "z")).getDoubleValue();
+            }
         }
-    }
 
-    /**
-     *
-     * @param context ThreadContext
-     * @return x IRubyObject
-     */
-    @JRubyMethod(name = "x")
+        /**
+         *
+         * @param context ThreadContext
+         * @return x IRubyObject
+         */
+        @JRubyMethod(name = "x")
 
-    public IRubyObject getX(ThreadContext context) {
+        public IRubyObject getX
+        (ThreadContext context
+        
+            ) {
         return context.runtime.newFloat(jx);
-    }
+        }
 
-    /**
-     *
-     * @param context ThreadContext
-     * @return y IRubyObject
-     */
-    @JRubyMethod(name = "y")
+        /**
+         *
+         * @param context ThreadContext
+         * @return y IRubyObject
+         */
+        @JRubyMethod(name = "y")
 
-    public IRubyObject getY(ThreadContext context) {
+        public IRubyObject getY
+        (ThreadContext context
+        
+            ) {
         return context.runtime.newFloat(jy);
-    }
+        }
 
-    /**
-     *
-     * @param context ThreadContext
-     * @return z IRubyObject
-     */
-    @JRubyMethod(name = "z")
-    public IRubyObject getZ(ThreadContext context) {
+        /**
+         *
+         * @param context ThreadContext
+         * @return z IRubyObject
+         */
+        @JRubyMethod(name = "z")
+        public IRubyObject getZ
+        (ThreadContext context
+        
+            ) {
         return context.runtime.newFloat(jz);
-    }
-
-    /**
-     *
-     * @param context ThreadContext
-     * @param other IRubyObject
-     * @return x IRubyObject
-     */
-    @JRubyMethod(name = "x=")
-
-    public IRubyObject setX(ThreadContext context, IRubyObject other) {
-        if (other instanceof RubyFloat) {
-            jx = ((RubyFloat) other).getValue();
-        } else {
-            jx = ((RubyFixnum) other).getDoubleValue();
         }
-        return other;
-    }
 
-    /**
-     *
-     * @param context ThreadContext
-     * @param other IRubyObject
-     * @return y IRubyObject
-     */
-    @JRubyMethod(name = "y=")
+        /**
+         *
+         * @param context ThreadContext
+         * @param other IRubyObject
+         * @return x IRubyObject
+         */
+        @JRubyMethod(name = "x=")
 
-    public IRubyObject setY(ThreadContext context, IRubyObject other) {
+        public IRubyObject setX
+        (ThreadContext context, IRubyObject other
+        
+            ) {
         if (other instanceof RubyFloat) {
-            jy = ((RubyFloat) other).getValue();
-        } else {
-            jy = ((RubyFixnum) other).getDoubleValue();
+                jx = ((RubyFloat) other).getValue();
+            } else {
+                jx = ((RubyFixnum) other).getDoubleValue();
+            }
+            return other;
         }
-        return other;
-    }
 
-    /**
-     *
-     * @param context ThreadContext
-     * @param other IRubyObject
-     * @return z IRubyObject
-     */
-    @JRubyMethod(name = "z=")
-    public IRubyObject setZ(ThreadContext context, IRubyObject other) {
+        /**
+         *
+         * @param context ThreadContext
+         * @param other IRubyObject
+         * @return y IRubyObject
+         */
+        @JRubyMethod(name = "y=")
+
+        public IRubyObject setY
+        (ThreadContext context, IRubyObject other
+        
+            ) {
         if (other instanceof RubyFloat) {
-            jz = ((RubyFloat) other).getValue();
-        } else {
-            jz = ((RubyFixnum) other).getDoubleValue();
+                jy = ((RubyFloat) other).getValue();
+            } else {
+                jy = ((RubyFixnum) other).getDoubleValue();
+            }
+            return other;
         }
-        return other;
-    }
 
-    /**
-     *
-     * @param context ThreadContext
-     * @param key as symbol
-     * @return value float
-     */
-    @JRubyMethod(name = "[]", required = 1)
+        /**
+         *
+         * @param context ThreadContext
+         * @param other IRubyObject
+         * @return z IRubyObject
+         */
+        @JRubyMethod(name = "z=")
+        public IRubyObject setZ
+        (ThreadContext context, IRubyObject other
+        
+            ) {
+        if (other instanceof RubyFloat) {
+                jz = ((RubyFloat) other).getValue();
+            } else {
+                jz = ((RubyFixnum) other).getDoubleValue();
+            }
+            return other;
+        }
 
-    public IRubyObject aref(ThreadContext context, IRubyObject key) {
+        /**
+         *
+         * @param context ThreadContext
+         * @param key as symbol
+         * @return value float
+         */
+        @JRubyMethod(name = "[]", required = 1)
+
+        public IRubyObject aref
+        (ThreadContext context, IRubyObject key
+        
+            ) {
         Ruby runtime = context.runtime;
-        if (key instanceof RubySymbol) {
-            if (key == RubySymbol.newSymbol(runtime, "x")) {
-                return runtime.newFloat(jx);
-            } else if (key == RubySymbol.newSymbol(runtime, "y")) {
-                return runtime.newFloat(jy);
-            } else if (key == RubySymbol.newSymbol(runtime, "z")) {
-                return runtime.newFloat(jz);
+            if (key instanceof RubySymbol) {
+                if (key == RubySymbol.newSymbol(runtime, "x")) {
+                    return runtime.newFloat(jx);
+                } else if (key == RubySymbol.newSymbol(runtime, "y")) {
+                    return runtime.newFloat(jy);
+                } else if (key == RubySymbol.newSymbol(runtime, "z")) {
+                    return runtime.newFloat(jz);
+                } else {
+                    throw runtime.newIndexError("invalid key");
+                }
             } else {
                 throw runtime.newIndexError("invalid key");
             }
-        } else {
-            throw runtime.newIndexError("invalid key");
         }
-    }
 
-    /**
-     * @param context ThreadContext
-     * @param key as symbol
-     * @param value as float
-     * @return value float
-     */
-    @JRubyMethod(name = "[]=")
+        /**
+         * @param context ThreadContext
+         * @param key as symbol
+         * @param value as float
+         * @return value float
+         */
+        @JRubyMethod(name = "[]=")
 
-    public IRubyObject aset(ThreadContext context, IRubyObject key, IRubyObject value) {
+        public IRubyObject aset
+        (ThreadContext context, IRubyObject key
+        , IRubyObject value
+        
+            ) {
         Ruby runtime = context.runtime;
-        if (key instanceof RubySymbol) {
-            if (key == RubySymbol.newSymbol(runtime, "x")) {
-                jx = (value instanceof RubyFloat)
-                        ? ((RubyFloat) value).getValue() : ((RubyFixnum) value).getDoubleValue();
-            } else if (key == RubySymbol.newSymbol(runtime, "y")) {
-                jy = (value instanceof RubyFloat)
-                        ? ((RubyFloat) value).getValue() : ((RubyFixnum) value).getDoubleValue();
-            } else if (key == RubySymbol.newSymbol(runtime, "z")) {
-                jz = (value instanceof RubyFloat)
-                        ? ((RubyFloat) value).getValue() : ((RubyFixnum) value).getDoubleValue();
+            if (key instanceof RubySymbol) {
+                if (key == RubySymbol.newSymbol(runtime, "x")) {
+                    jx = (value instanceof RubyFloat)
+                            ? ((RubyFloat) value).getValue() : ((RubyFixnum) value).getDoubleValue();
+                } else if (key == RubySymbol.newSymbol(runtime, "y")) {
+                    jy = (value instanceof RubyFloat)
+                            ? ((RubyFloat) value).getValue() : ((RubyFixnum) value).getDoubleValue();
+                } else if (key == RubySymbol.newSymbol(runtime, "z")) {
+                    jz = (value instanceof RubyFloat)
+                            ? ((RubyFloat) value).getValue() : ((RubyFixnum) value).getDoubleValue();
+                } else {
+                    throw runtime.newIndexError("invalid key");
+                }
             } else {
                 throw runtime.newIndexError("invalid key");
             }
-        } else {
-            throw runtime.newIndexError("invalid key");
+            return value;
         }
-        return value;
-    }
 
-    /**
-     *
-     * @param context ThreadContext
-     * @param other IRubyObject
-     * @return distance float
-     */
-    @JRubyMethod(name = "dist", required = 1)
+        /**
+         *
+         * @param context ThreadContext
+         * @param other IRubyObject
+         * @return distance float
+         */
+        @JRubyMethod(name = "dist", required = 1)
 
-    public IRubyObject dist(ThreadContext context, IRubyObject other) {
+        public IRubyObject dist
+        (ThreadContext context, IRubyObject other
+        
+            ) {
         Vec3 b = null;
-        if (other instanceof Vec3) {
-            b = (Vec3) other.toJava(Vec3.class);
-        } else {
-            throw context.runtime.newTypeError("argument should be Vec3D");
+            if (other instanceof Vec3) {
+                b = (Vec3) other.toJava(Vec3.class);
+            } else {
+                throw context.runtime.newTypeError("argument should be Vec3D");
+            }
+            double result = Math.sqrt((jx - b.jx) * (jx - b.jx) + (jy - b.jy) * (jy - b.jy) + (jz - b.jz) * (jz - b.jz));
+            return context.runtime.newFloat(result);
         }
-        double result = Math.sqrt((jx - b.jx) * (jx - b.jx) + (jy - b.jy) * (jy - b.jy) + (jz - b.jz) * (jz - b.jz));
-        return context.runtime.newFloat(result);
-    }
 
-    /**
-     *
-     * @param context ThreadContext
-     * @param other IRubyObject
-     * @return distance squared float
-     */
-    @JRubyMethod(name = "dist_squared", required = 1)
+        /**
+         *
+         * @param context ThreadContext
+         * @param other IRubyObject
+         * @return distance squared float
+         */
+        @JRubyMethod(name = "dist_squared", required = 1)
 
-    public IRubyObject dist_squared(ThreadContext context, IRubyObject other) {
+        public IRubyObject dist_squared
+        (ThreadContext context, IRubyObject other
+        
+            ) {
         Vec3 b = null;
-        if (other instanceof Vec3) {
-            b = (Vec3) other.toJava(Vec3.class);
-        } else {
-            throw context.runtime.newTypeError("argument should be Vec3D");
+            if (other instanceof Vec3) {
+                b = (Vec3) other.toJava(Vec3.class);
+            } else {
+                throw context.runtime.newTypeError("argument should be Vec3D");
+            }
+            double result = (jx - b.jx) * (jx - b.jx) + (jy - b.jy) * (jy - b.jy) + (jz - b.jz) * (jz - b.jz);
+            return context.runtime.newFloat(result);
         }
-        double result = (jx - b.jx) * (jx - b.jx) + (jy - b.jy) * (jy - b.jy) + (jz - b.jz) * (jz - b.jz);
-        return context.runtime.newFloat(result);
-    }
 
-    /**
-     *
-     *
-     * @param context ThreadContext
-     * @param other IRubyObject
-     * @return cross product IRubyObject
-     */
-    @JRubyMethod(name = "cross", required = 1)
+        /**
+         *
+         *
+         * @param context ThreadContext
+         * @param other IRubyObject
+         * @return cross product IRubyObject
+         */
+        @JRubyMethod(name = "cross", required = 1)
 
-    public IRubyObject cross(ThreadContext context, IRubyObject other) {
+        public IRubyObject cross
+        (ThreadContext context, IRubyObject other
+        
+            ) {
         Ruby runtime = context.runtime;
-        Vec3 vec = null;
-        if (other instanceof Vec3) {
-            vec = (Vec3) other.toJava(Vec3.class);
-        } else {
-            throw runtime.newTypeError("argument should be Vec3D");
+            Vec3 vec = null;
+            if (other instanceof Vec3) {
+                vec = (Vec3) other.toJava(Vec3.class);
+            } else {
+                throw runtime.newTypeError("argument should be Vec3D");
+            }
+            return Vec3.rbNew(context, other.getMetaClass(), new IRubyObject[]{
+                runtime.newFloat(jy * vec.jz - jz * vec.jy),
+                runtime.newFloat(jz * vec.jx - jx * vec.jz),
+                runtime.newFloat(jx * vec.jy - jy * vec.jx)
+            }
+            );
         }
-        return Vec3.rbNew(context, other.getMetaClass(), new IRubyObject[]{
-            runtime.newFloat(jy * vec.jz - jz * vec.jy),
-            runtime.newFloat(jz * vec.jx - jx * vec.jz),
-            runtime.newFloat(jx * vec.jy - jy * vec.jx)
+
+        /**
+         *
+         * @param context ThreadContext
+         * @param other IRubyObject
+         * @return dot product IRubyObject
+         */
+        @JRubyMethod(name = "dot", required = 1)
+
+        public IRubyObject dot
+        (ThreadContext context, IRubyObject other
+        
+            ) {
+        Ruby runtime = context.runtime;
+            Vec3 b = null;
+            if (other instanceof Vec3) {
+                b = (Vec3) other.toJava(Vec3.class);
+            } else {
+                throw runtime.newTypeError("argument should be Vec3D");
+            }
+            return runtime.newFloat(jx * b.jx + jy * b.jy + jz * b.jz);
         }
-        );
-    }
 
-    /**
-     *
-     * @param context ThreadContext
-     * @param other IRubyObject
-     * @return dot product IRubyObject
-     */
-    @JRubyMethod(name = "dot", required = 1)
+        /**
+         *
+         * @param context ThreadContext
+         * @param other IRubyObject
+         * @return new Vec3 object (ruby)
+         */
+        @JRubyMethod(name = "+", required = 1)
 
-    public IRubyObject dot(ThreadContext context, IRubyObject other) {
+        public IRubyObject op_add
+        (ThreadContext context, IRubyObject other
+        
+            ) {
         Ruby runtime = context.runtime;
-        Vec3 b = null;
-        if (other instanceof Vec3) {
-            b = (Vec3) other.toJava(Vec3.class);
-        } else {
-            throw runtime.newTypeError("argument should be Vec3D");
+            Vec3 b = (Vec3) other.toJava(Vec3.class);
+            return Vec3.rbNew(context, other.getMetaClass(), new IRubyObject[]{
+                runtime.newFloat(jx + b.jx),
+                runtime.newFloat(jy + b.jy),
+                runtime.newFloat(jz + b.jz)});
         }
-        return runtime.newFloat(jx * b.jx + jy * b.jy + jz * b.jz);
-    }
 
-    /**
-     *
-     * @param context ThreadContext
-     * @param other IRubyObject
-     * @return new Vec3 object (ruby)
-     */
-    @JRubyMethod(name = "+", required = 1)
+        /**
+         *
+         * @param context ThreadContext
+         * @param other IRubyObject
+         * @return new Vec3 object (ruby)
+         */
+        @JRubyMethod(name = "-")
 
-    public IRubyObject op_add(ThreadContext context, IRubyObject other) {
+        public IRubyObject op_sub
+        (ThreadContext context, IRubyObject other
+        
+            ) {
         Ruby runtime = context.runtime;
-        Vec3 b = (Vec3) other.toJava(Vec3.class);
-        return Vec3.rbNew(context, other.getMetaClass(), new IRubyObject[]{
-            runtime.newFloat(jx + b.jx),
-            runtime.newFloat(jy + b.jy),
-            runtime.newFloat(jz + b.jz)});
-    }
-
-    /**
-     *
-     * @param context ThreadContext
-     * @param other IRubyObject
-     * @return new Vec3 object (ruby)
-     */
-    @JRubyMethod(name = "-")
-
-    public IRubyObject op_sub(ThreadContext context, IRubyObject other) {
-        Ruby runtime = context.runtime;
-        Vec3 b = null;
-        if (other instanceof Vec3) {
-            b = (Vec3) other.toJava(Vec3.class);
-        } else {
-            throw runtime.newTypeError("argument should be Vec3D");
+            Vec3 b = null;
+            if (other instanceof Vec3) {
+                b = (Vec3) other.toJava(Vec3.class);
+            } else {
+                throw runtime.newTypeError("argument should be Vec3D");
+            }
+            return Vec3.rbNew(context, other.getMetaClass(), new IRubyObject[]{
+                runtime.newFloat(jx - b.jx),
+                runtime.newFloat(jy - b.jy),
+                runtime.newFloat(jz - b.jz)});
         }
-        return Vec3.rbNew(context, other.getMetaClass(), new IRubyObject[]{
-            runtime.newFloat(jx - b.jx),
-            runtime.newFloat(jy - b.jy),
-            runtime.newFloat(jz - b.jz)});
-    }
 
-    /**
-     *
-     * @param context ThreadContext
-     * @param scalar IRubyObject
-     * @return new Vec3 object (ruby)
-     */
-    @JRubyMethod(name = "*", required = 1)
+        /**
+         *
+         * @param context ThreadContext
+         * @param scalar IRubyObject
+         * @return new Vec3 object (ruby)
+         */
+        @JRubyMethod(name = "*", required = 1)
 
-    public IRubyObject op_mul(ThreadContext context, IRubyObject scalar) {
+        public IRubyObject op_mul
+        (ThreadContext context, IRubyObject scalar
+        
+            ) {
         Ruby runtime = context.runtime;
-        double multi = (scalar instanceof RubyFloat)
-                ? ((RubyFloat) scalar).getValue() : ((RubyFixnum) scalar).getDoubleValue();
-        return Vec3.rbNew(context, this.getMetaClass(), new IRubyObject[]{
-            runtime.newFloat(jx * multi),
-            runtime.newFloat(jy * multi),
-            runtime.newFloat(jz * multi)});
-    }
-
-    /**
-     *
-     * @param context ThreadContext
-     * @param scalar IRubyObject
-     * @return new Vec3 object (ruby)
-     */
-    @JRubyMethod(name = "/", required = 1)
-
-    public IRubyObject op_div(ThreadContext context, IRubyObject scalar) {
-        Ruby runtime = context.runtime;
-        double divisor = (scalar instanceof RubyFloat)
-                ? ((RubyFloat) scalar).getValue() : ((RubyFixnum) scalar).getDoubleValue();
-        if (Math.abs(divisor) < Vec3.EPSILON) {
-            return this;
+            double multi = (scalar instanceof RubyFloat)
+                    ? ((RubyFloat) scalar).getValue() : ((RubyFixnum) scalar).getDoubleValue();
+            return Vec3.rbNew(context, this.getMetaClass(), new IRubyObject[]{
+                runtime.newFloat(jx * multi),
+                runtime.newFloat(jy * multi),
+                runtime.newFloat(jz * multi)});
         }
-        return Vec3.rbNew(context, this.getMetaClass(), new IRubyObject[]{
-            runtime.newFloat(jx / divisor),
-            runtime.newFloat(jy / divisor),
-            runtime.newFloat(jz / divisor)});
-    }
 
-    /**
-     *
-     * @param context ThreadContext
-     * @return magnitude squared IRubyObject
-     */
-    @JRubyMethod(name = "mag_squared")
+        /**
+         *
+         * @param context ThreadContext
+         * @param scalar IRubyObject
+         * @return new Vec3 object (ruby)
+         */
+        @JRubyMethod(name = "/", required = 1)
 
-    public IRubyObject mag_squared(ThreadContext context) {
-        return context.runtime.newFloat(jx * jx + jy * jy + jz * jz);
-    }
-
-    /**
-     *
-     * @param context ThreadContext
-     * @return magnitude IRubyObject
-     */
-    @JRubyMethod(name = "mag")
-
-    public IRubyObject mag(ThreadContext context) {
-        return context.runtime.newFloat(Math.sqrt(jx * jx + jy * jy + jz * jz));
-    }
-
-    /**
-     * Call yield if block given, do nothing if yield == false else set_mag to
-     * given scalar
-     *
-     * @param context ThreadContext
-     * @param scalar double value to set
-     * @param block should return a boolean (optional)
-     * @return magnitude IRubyObject
-     */
-    @JRubyMethod(name = "set_mag")
-
-    public IRubyObject set_mag(ThreadContext context, IRubyObject scalar, Block block) {
-        if (block.isGiven()) {
-            if (!(boolean) block.yield(context, scalar).toJava(Boolean.class)) {
+        public IRubyObject op_div
+        (ThreadContext context, IRubyObject scalar
+        
+            ) {
+        Ruby runtime = context.runtime;
+            double divisor = (scalar instanceof RubyFloat)
+                    ? ((RubyFloat) scalar).getValue() : ((RubyFixnum) scalar).getDoubleValue();
+            if (Math.abs(divisor) < Vec3.EPSILON) {
                 return this;
             }
+            return Vec3.rbNew(context, this.getMetaClass(), new IRubyObject[]{
+                runtime.newFloat(jx / divisor),
+                runtime.newFloat(jy / divisor),
+                runtime.newFloat(jz / divisor)});
         }
-        double new_mag = (scalar instanceof RubyFloat)
-                ? ((RubyFloat) scalar).getValue() : ((RubyFixnum) scalar).getDoubleValue();
-        double current = Math.sqrt(jx * jx + jy * jy + jz * jz);
-        if (current > EPSILON) {
-            jx *= new_mag / current;
-            jy *= new_mag / current;
-            jz *= new_mag / current;
+
+        /**
+         *
+         * @param context ThreadContext
+         * @return magnitude squared IRubyObject
+         */
+        @JRubyMethod(name = "mag_squared")
+
+        public IRubyObject mag_squared
+        (ThreadContext context
+        
+            ) {
+        return context.runtime.newFloat(jx * jx + jy * jy + jz * jz);
         }
-        return this;
-    }
 
-    /**
-     *
-     * @param context ThreadContext
-     * @return this as a ruby object
-     */
-    @JRubyMethod(name = "normalize!")
+        /**
+         *
+         * @param context ThreadContext
+         * @return magnitude IRubyObject
+         */
+        @JRubyMethod(name = "mag")
 
-    public IRubyObject normalize_bang(ThreadContext context) {
-        if (Math.abs(jx) < EPSILON && Math.abs(jy) < EPSILON && Math.abs(jz) < EPSILON) {
+        public IRubyObject mag
+        (ThreadContext context
+        
+            ) {
+        return context.runtime.newFloat(Math.sqrt(jx * jx + jy * jy + jz * jz));
+        }
+
+        /**
+         * Call yield if block given, do nothing if yield == false else set_mag
+         * to given scalar
+         *
+         * @param context ThreadContext
+         * @param scalar double value to set
+         * @param block should return a boolean (optional)
+         * @return magnitude IRubyObject
+         */
+        @JRubyMethod(name = "set_mag")
+
+        public IRubyObject set_mag
+        (ThreadContext context, IRubyObject scalar
+        , Block block
+        
+            ) {
+        if (block.isGiven()) {
+                if (!(boolean) block.yield(context, scalar).toJava(Boolean.class)) {
+                    return this;
+                }
+            }
+            double new_mag = (scalar instanceof RubyFloat)
+                    ? ((RubyFloat) scalar).getValue() : ((RubyFixnum) scalar).getDoubleValue();
+            double current = Math.sqrt(jx * jx + jy * jy + jz * jz);
+            if (current > EPSILON) {
+                jx *= new_mag / current;
+                jy *= new_mag / current;
+                jz *= new_mag / current;
+            }
             return this;
         }
-        double mag = Math.sqrt(jx * jx + jy * jy + jz * jz);
-        jx /= mag;
-        jy /= mag;
-        jz /= mag;
-        return this;
-    }
 
-    /**
-     *
-     * @param context ThreadContext
-     * @return new normalized Vec3D object (ruby)
-     */
-    @JRubyMethod(name = "normalize")
+        /**
+         *
+         * @param context ThreadContext
+         * @return this as a ruby object
+         */
+        @JRubyMethod(name = "normalize!")
 
-    public IRubyObject normalize(ThreadContext context) {
+        public IRubyObject normalize_bang
+        (ThreadContext context
+        
+            ) {
+        if (Math.abs(jx) < EPSILON && Math.abs(jy) < EPSILON && Math.abs(jz) < EPSILON) {
+                return this;
+            }
+            double mag = Math.sqrt(jx * jx + jy * jy + jz * jz);
+            jx /= mag;
+            jy /= mag;
+            jz /= mag;
+            return this;
+        }
+
+        /**
+         *
+         * @param context ThreadContext
+         * @return new normalized Vec3D object (ruby)
+         */
+        @JRubyMethod(name = "normalize")
+
+        public IRubyObject normalize
+        (ThreadContext context
+        
+            ) {
         Ruby runtime = context.runtime;
-        double mag = Math.sqrt(jx * jx + jy * jy + jz * jz);
-        if (mag < EPSILON) {
+            double mag = Math.sqrt(jx * jx + jy * jy + jz * jz);
+            if (mag < EPSILON) {
+                return Vec3.rbNew(context, this.getMetaClass(), new IRubyObject[]{
+                    runtime.newFloat(jx),
+                    runtime.newFloat(jy),
+                    runtime.newFloat(jz)});
+            }
+            return Vec3.rbNew(context, this.getMetaClass(), new IRubyObject[]{
+                runtime.newFloat(jx / mag),
+                runtime.newFloat(jy / mag),
+                runtime.newFloat(jz / mag)});
+        }
+
+        /**
+         * Example of a regular ruby class method
+         *
+         * @param context ThreadContext
+         * @param klazz IRubyObject
+         * @return new random Vec3D object (ruby)
+         */
+        @JRubyMethod(name = "random", meta = true)
+
+        public static IRubyObject random_direction
+        (ThreadContext context, IRubyObject klazz
+        
+            ) {
+        Ruby runtime = context.runtime;
+            double angle = Math.random() * Math.PI * 2;
+            double vz = Math.random() * 2 - 1;
+            double vx = Math.sqrt(1 - vz * vz) * Math.cos(angle);
+            double vy = Math.sqrt(1 - vz * vz) * Math.sin(angle);
+
+            return Vec3.rbNew(context, klazz, new IRubyObject[]{
+                runtime.newFloat(vx),
+                runtime.newFloat(vy),
+                runtime.newFloat(vz)});
+        }
+
+        /**
+         *
+         * @param context ThreadContext
+         * @param other IRubyObject another Vec3D
+         * @return angle IRubyObject in radians
+         */
+        @JRubyMethod(name = "angle_between")
+
+        public IRubyObject angleBetween
+        (ThreadContext context, IRubyObject other
+        
+            ) {
+        Ruby runtime = context.runtime;
+            Vec3 vec = (Vec3) other.toJava(Vec3.class);
+            // We get NaN if we pass in a zero vector which can cause problems
+            // Zero seems like a reasonable angle between a (0,0,0) vector and something else
+            if (jx == 0 && jy == 0 && jz == 0) {
+                return runtime.newFloat(0.0);
+            }
+            if (vec.jx == 0 && vec.jy == 0 && vec.jz == 0) {
+                return runtime.newFloat(0.0);
+            }
+
+            double dot = jx * vec.jx + jy * vec.jy + jz * vec.jz;
+            double v1mag = Math.sqrt(jx * jx + jy * jy + jz * jz);
+            double v2mag = Math.sqrt(vec.jx * vec.jx + vec.jy * vec.jy + vec.jz * vec.jz);
+            // This should be a number between -1 and 1, since it's "normalized"
+            double amt = dot / (v1mag * v2mag);
+            if (amt <= -1) {
+                return runtime.newFloat(Math.PI);
+            } else if (amt >= 1) {
+                return runtime.newFloat(0.0);
+            }
+            return runtime.newFloat(Math.acos(amt));
+        }
+
+        /**
+         *
+         * @param context ThreadContext
+         * @return IRubyObject copy
+         */
+        @JRubyMethod(name = {"copy", "dup"})
+
+        public IRubyObject copy
+        (ThreadContext context
+        
+            ) {
+        Ruby runtime = context.runtime;
             return Vec3.rbNew(context, this.getMetaClass(), new IRubyObject[]{
                 runtime.newFloat(jx),
                 runtime.newFloat(jy),
                 runtime.newFloat(jz)});
         }
-        return Vec3.rbNew(context, this.getMetaClass(), new IRubyObject[]{
-            runtime.newFloat(jx / mag),
-            runtime.newFloat(jy / mag),
-            runtime.newFloat(jz / mag)});
-    }
 
-    /**
-     * Example of a regular ruby class method
-     *
-     * @param context ThreadContext
-     * @param klazz IRubyObject
-     * @return new random Vec3D object (ruby)
-     */
-    @JRubyMethod(name = "random", meta = true)
+        /**
+         *
+         * @param context ThreadContext
+         * @return IRubyObject array of float
+         */
+        @JRubyMethod(name = "to_a")
 
-    public static IRubyObject random_direction(ThreadContext context, IRubyObject klazz) {
+        public IRubyObject toArray
+        (ThreadContext context
+        
+            ) {
         Ruby runtime = context.runtime;
-        double angle = Math.random() * Math.PI * 2;
-        double vz = Math.random() * 2 - 1;
-        double vx = Math.sqrt(1 - vz * vz) * Math.cos(angle);
-        double vy = Math.sqrt(1 - vz * vz) * Math.sin(angle);
-
-        return Vec3.rbNew(context, klazz, new IRubyObject[]{
-            runtime.newFloat(vx),
-            runtime.newFloat(vy),
-            runtime.newFloat(vz)});
-    }
-
-    /**
-     *
-     * @param context ThreadContext
-     * @param other IRubyObject another Vec3D
-     * @return angle IRubyObject in radians
-     */
-    @JRubyMethod(name = "angle_between")
-
-    public IRubyObject angleBetween(ThreadContext context, IRubyObject other) {
-        Ruby runtime = context.runtime;
-        Vec3 vec = (Vec3) other.toJava(Vec3.class);
-        // We get NaN if we pass in a zero vector which can cause problems
-        // Zero seems like a reasonable angle between a (0,0,0) vector and something else
-        if (jx == 0 && jy == 0 && jz == 0) {
-            return runtime.newFloat(0.0);
-        }
-        if (vec.jx == 0 && vec.jy == 0 && vec.jz == 0) {
-            return runtime.newFloat(0.0);
+            return RubyArray.newArray(context.runtime, new IRubyObject[]{
+                runtime.newFloat(jx),
+                runtime.newFloat(jy),
+                runtime.newFloat(jz)});
         }
 
-        double dot = jx * vec.jx + jy * vec.jy + jz * vec.jz;
-        double v1mag = Math.sqrt(jx * jx + jy * jy + jz * jz);
-        double v2mag = Math.sqrt(vec.jx * vec.jx + vec.jy * vec.jy + vec.jz * vec.jz);
-        // This should be a number between -1 and 1, since it's "normalized"
-        double amt = dot / (v1mag * v2mag);
-        if (amt <= -1) {
-            return runtime.newFloat(Math.PI);
-        } else if (amt >= 1) {
-            return runtime.newFloat(0.0);
-        }
-        return runtime.newFloat(Math.acos(amt));
-    }
+        /**
+         * To vertex
+         *
+         * @param context ThreadContext
+         * @param object IRubyObject vertex renderer
+         */
+        @JRubyMethod(name = "to_vertex")
 
-    /**
-     *
-     * @param context ThreadContext
-     * @return IRubyObject copy
-     */
-    @JRubyMethod(name = {"copy", "dup"})
-
-    public IRubyObject copy(ThreadContext context) {
-        Ruby runtime = context.runtime;
-        return Vec3.rbNew(context, this.getMetaClass(), new IRubyObject[]{
-            runtime.newFloat(jx),
-            runtime.newFloat(jy),
-            runtime.newFloat(jz)});
-    }
-
-    /**
-     *
-     * @param context ThreadContext
-     * @return IRubyObject array of float
-     */
-    @JRubyMethod(name = "to_a")
-
-    public IRubyObject toArray(ThreadContext context) {
-        Ruby runtime = context.runtime;
-        return RubyArray.newArray(context.runtime, new IRubyObject[]{
-            runtime.newFloat(jx),
-            runtime.newFloat(jy),
-            runtime.newFloat(jz)});
-    }
-
-    /**
-     * To vertex
-     *
-     * @param context ThreadContext
-     * @param object IRubyObject vertex renderer
-     */
-    @JRubyMethod(name = "to_vertex")
-
-    public void toVertex(ThreadContext context, IRubyObject object) {
+        public void toVertex
+        (ThreadContext context, IRubyObject object
+        
+            ) {
         JRender renderer = (JRender) object.toJava(JRender.class);
-        renderer.vertex(jx, jy, jz);
-    }
+            renderer.vertex(jx, jy, jz);
+        }
 
-    /**
-     * To curve vertex
-     *
-     * @param context ThreadContext
-     * @param object IRubyObject vertex renderer
-     */
-    @JRubyMethod(name = "to_curve_vertex")
+        /**
+         * To curve vertex
+         *
+         * @param context ThreadContext
+         * @param object IRubyObject vertex renderer
+         */
+        @JRubyMethod(name = "to_curve_vertex")
 
-    public void toCurveVertex(ThreadContext context, IRubyObject object) {
+        public void toCurveVertex
+        (ThreadContext context, IRubyObject object
+        
+            ) {
         JRender renderer = (JRender) object.toJava(JRender.class);
-        renderer.curveVertex(jx, jy, jz);
-    }
+            renderer.curveVertex(jx, jy, jz);
+        }
 
-    /**
-     * Sends this Vec3D as a processing vertex uv
-     *
-     * @param context ThreadContext
-     * @param args IRubyObject[]
-     */
-    @JRubyMethod(name = "to_vertex_uv", rest = true)
+        /**
+         * Sends this Vec3D as a processing vertex uv
+         *
+         * @param context ThreadContext
+         * @param args IRubyObject[]
+         */
+        @JRubyMethod(name = "to_vertex_uv", rest = true)
 
-    public void toVertexUV(ThreadContext context, IRubyObject[] args) {
+        public void toVertexUV
+        (ThreadContext context, IRubyObject[] args
+        
+            ) {
         int count = Arity.checkArgumentCount(context.runtime, args, Arity.OPTIONAL.getValue(), 3);
-        double u = 0;
-        double v = 0;
-        if (count == 3) {
-            u = (args[1] instanceof RubyFloat)
-                    ? ((RubyFloat) args[1]).getValue() : ((RubyFixnum) args[1]).getDoubleValue();
-            v = (args[2] instanceof RubyFloat)
-                    ? ((RubyFloat) args[2]).getValue() : ((RubyFixnum) args[2]).getDoubleValue();
+            double u = 0;
+            double v = 0;
+            if (count == 3) {
+                u = (args[1] instanceof RubyFloat)
+                        ? ((RubyFloat) args[1]).getValue() : ((RubyFixnum) args[1]).getDoubleValue();
+                v = (args[2] instanceof RubyFloat)
+                        ? ((RubyFloat) args[2]).getValue() : ((RubyFixnum) args[2]).getDoubleValue();
+            }
+            if (count == 2) {
+                Vec2 texture = (Vec2) args[1].toJava(Vec2.class);
+                u = texture.javax();
+                v = texture.javay();
+            }
+            JRender renderer = (JRender) args[0].toJava(JRender.class);
+            renderer.vertex(jx, jy, jz, u, v);
         }
-        if (count == 2) {
-            Vec2 texture = (Vec2) args[1].toJava(Vec2.class);
-            u = texture.javax();
-            v = texture.javay();
-        }
-        JRender renderer = (JRender) args[0].toJava(JRender.class);
-        renderer.vertex(jx, jy, jz, u, v);
-    }
 
-    /**
-     * Sends this Vec3D as a processing normal
-     *
-     * @param context ThreadContext
-     * @param object IRubyObject vertex renderer
-     */
-    @JRubyMethod(name = "to_normal")
+        /**
+         * Sends this Vec3D as a processing normal
+         *
+         * @param context ThreadContext
+         * @param object IRubyObject vertex renderer
+         */
+        @JRubyMethod(name = "to_normal")
 
-    public void toNormal(ThreadContext context, IRubyObject object) {
+        public void toNormal
+        (ThreadContext context, IRubyObject object
+        
+            ) {
         JRender renderer = (JRender) object.toJava(JRender.class);
-        renderer.normal(jx, jy, jz);
-    }
-
-    /**
-     * For jruby-9000 we alias to inspect
-     *
-     * @param context ThreadContext
-     * @return IRubyObject to_s
-     */
-    @JRubyMethod(name = {"to_s", "inspect"})
-
-    public IRubyObject to_s(ThreadContext context) {
-        return context.runtime.newString(String.format("Vec3D(x = %4.4f, y = %4.4f, z = %4.4f)", jx, jy, jz));
-    }
-
-    /**
-     * Java hash
-     *
-     * @return hash int
-     */
-    @Override
-    public int hashCode() {
-        int hash = 7;
-        hash = 97 * hash + (int) (Double.doubleToLongBits(this.jx) ^ (Double.doubleToLongBits(this.jx) >>> 32));
-        hash = 97 * hash + (int) (Double.doubleToLongBits(this.jy) ^ (Double.doubleToLongBits(this.jy) >>> 32));
-        hash = 97 * hash + (int) (Double.doubleToLongBits(this.jz) ^ (Double.doubleToLongBits(this.jz) >>> 32));
-        return hash;
-    }
-
-    /**
-     * Java Equals
-     *
-     * @param obj Object
-     * @return result boolean
-     */
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == this) {
-            return true;
+            renderer.normal(jx, jy, jz);
         }
-        if (obj instanceof Vec3) {
-            final Vec3 other = (Vec3) obj;
-            if ((Double.compare(jx, (Double) other.jx) == 0)
-                    && (Double.compare(jy, (Double) other.jy) == 0)
-                    && (Double.compare(jz, (Double) other.jz) == 0)) {
+
+        /**
+         * For jruby-9000 we alias to inspect
+         *
+         * @param context ThreadContext
+         * @return IRubyObject to_s
+         */
+        @JRubyMethod(name = {"to_s", "inspect"})
+
+        public IRubyObject to_s
+        (ThreadContext context
+        
+            ) {
+        return context.runtime.newString(String.format("Vec3D(x = %4.4f, y = %4.4f, z = %4.4f)", jx, jy, jz));
+        }
+
+        /**
+         * Java hash
+         *
+         * @return hash int
+         */
+        @Override
+        public int hashCode
+        
+            () {
+        int hash = 7;
+            hash = 97 * hash + (int) (Double.doubleToLongBits(this.jx) ^ (Double.doubleToLongBits(this.jx) >>> 32));
+            hash = 97 * hash + (int) (Double.doubleToLongBits(this.jy) ^ (Double.doubleToLongBits(this.jy) >>> 32));
+            hash = 97 * hash + (int) (Double.doubleToLongBits(this.jz) ^ (Double.doubleToLongBits(this.jz) >>> 32));
+            return hash;
+        }
+
+        /**
+         * Java Equals
+         *
+         * @param obj Object
+         * @return result boolean
+         */
+        @Override
+        public boolean equals
+        (Object obj
+        
+            ) {
+        if (obj == this) {
                 return true;
             }
+            if (obj instanceof Vec3) {
+                final Vec3 other = (Vec3) obj;
+                if ((Double.compare(jx, (Double) other.jx) == 0)
+                        && (Double.compare(jy, (Double) other.jy) == 0)
+                        && (Double.compare(jz, (Double) other.jz) == 0)) {
+                    return true;
+                }
 
+            }
+            return false;
         }
-        return false;
-    }
 
-    /**
-     *
-     * @param context ThreadContext
-     * @param other IRubyObject
-     * @return result IRubyObject as boolean
-     */
-    @JRubyMethod(name = "eql?", required = 1)
+        /**
+         *
+         * @param context ThreadContext
+         * @param other IRubyObject
+         * @return result IRubyObject as boolean
+         */
+        @JRubyMethod(name = "eql?", required = 1)
 
-    public IRubyObject eql_p(ThreadContext context, IRubyObject other) {
+        public IRubyObject eql_p
+        (ThreadContext context, IRubyObject other
+        
+            ) {
         Ruby runtime = context.runtime;
-        if (other == this) {
-            return runtime.newBoolean(true);
-        }
-        if (other instanceof Vec3) {
-            Vec3 v = (Vec3) other.toJava(Vec3.class);
-            if ((Double.compare(jx, (Double) v.jx) == 0)
-                    && (Double.compare(jy, (Double) v.jy) == 0)
-                    && (Double.compare(jz, (Double) v.jz) == 0)) {
+            if (other == this) {
                 return runtime.newBoolean(true);
             }
+            if (other instanceof Vec3) {
+                Vec3 v = (Vec3) other.toJava(Vec3.class);
+                if ((Double.compare(jx, (Double) v.jx) == 0)
+                        && (Double.compare(jy, (Double) v.jy) == 0)
+                        && (Double.compare(jz, (Double) v.jz) == 0)) {
+                    return runtime.newBoolean(true);
+                }
 
+            }
+            return runtime.newBoolean(false);
         }
-        return runtime.newBoolean(false);
-    }
 
-    /**
-     *
-     * @param context ThreadContext
-     * @param other IRubyObject
-     * @return result IRubyObject as boolean
-     */
-    @JRubyMethod(name = "==", required = 1)
+        /**
+         *
+         * @param context ThreadContext
+         * @param other IRubyObject
+         * @return result IRubyObject as boolean
+         */
+        @JRubyMethod(name = "==", required = 1)
 
-    @Override
-    public IRubyObject op_equal(ThreadContext context, IRubyObject other) {
+        @Override
+        public IRubyObject op_equal
+        (ThreadContext context, IRubyObject other
+        
+            ) {
         Ruby runtime = context.runtime;
-        if (other == this) {
-            return runtime.newBoolean(true);
-        }
-        if (other instanceof Vec3) {
-            Vec3 v = (Vec3) other.toJava(Vec3.class);
-            double diff = jx - v.jx;
-            if ((diff < 0 ? -diff : diff) > Vec3.EPSILON) {
-                return runtime.newBoolean(false);
+            if (other == this) {
+                return runtime.newBoolean(true);
             }
-            diff = jy - v.jy;
-            if ((diff < 0 ? -diff : diff) > Vec3.EPSILON) {
-                return runtime.newBoolean(false);
+            if (other instanceof Vec3) {
+                Vec3 v = (Vec3) other.toJava(Vec3.class);
+                double diff = jx - v.jx;
+                if ((diff < 0 ? -diff : diff) > Vec3.EPSILON) {
+                    return runtime.newBoolean(false);
+                }
+                diff = jy - v.jy;
+                if ((diff < 0 ? -diff : diff) > Vec3.EPSILON) {
+                    return runtime.newBoolean(false);
+                }
+                diff = jz - v.jz;
+                return runtime.newBoolean((diff < 0 ? -diff : diff) < Vec3.EPSILON);
             }
-            diff = jz - v.jz;
-            return runtime.newBoolean((diff < 0 ? -diff : diff) < Vec3.EPSILON);
+            return runtime.newBoolean(false);
         }
-        return runtime.newBoolean(false);
     }
-}

--- a/src/monkstone/vecmath/vec3/Vec3.java
+++ b/src/monkstone/vecmath/vec3/Vec3.java
@@ -94,757 +94,635 @@ public final class Vec3 extends RubyObject {
                     ? ((RubyFloat) args[2]).getValue() : ((RubyFixnum) args[2]).getDoubleValue();
         } // allow ruby ducktyping in constructor
         if (count == 1) {
-            if (!(args[0].respondsTo("x"))) {throw context.runtime.newTypeError(args[0].getType() + " doesn't respond_to :x & :y");}
+            if (!(args[0].respondsTo("x"))) {
+                throw context.runtime.newTypeError(args[0].getType() + " doesn't respond_to :x & :y");
+            }
             jx = ((args[0].callMethod(context, "x")) instanceof RubyFloat)
                     ? ((RubyFloat) args[0].callMethod(context, "x")).getValue() : ((RubyFixnum) args[0].callMethod(context, "x")).getDoubleValue();
             jy = ((args[0].callMethod(context, "y")) instanceof RubyFloat)
                     ? ((RubyFloat) args[0].callMethod(context, "y")).getValue() : ((RubyFixnum) args[0].callMethod(context, "y")).getDoubleValue();
-            if (!(args[0].respondsTo("z"))) {return;} // allow promotion from 2D to 3D, sets jz = 0
+            if (!(args[0].respondsTo("z"))) {
+                return;
+            } // allow promotion from 2D to 3D, sets jz = 0
             jz = ((args[0].callMethod(context, "z")) instanceof RubyFloat) ? ((RubyFloat) args[0].callMethod(context, "z")).getValue() : ((RubyFixnum) args[0].callMethod(context, "z")).getDoubleValue();
-            }
-        }
-
-        /**
-         *
-         * @param context ThreadContext
-         * @return x IRubyObject
-         */
-        @JRubyMethod(name = "x")
-
-        public IRubyObject getX
-        (ThreadContext context
-
-            ) {
-        return context.runtime.newFloat(jx);
-        }
-
-        /**
-         *
-         * @param context ThreadContext
-         * @return y IRubyObject
-         */
-        @JRubyMethod(name = "y")
-
-        public IRubyObject getY
-        (ThreadContext context
-
-            ) {
-        return context.runtime.newFloat(jy);
-        }
-
-        /**
-         *
-         * @param context ThreadContext
-         * @return z IRubyObject
-         */
-        @JRubyMethod(name = "z")
-        public IRubyObject getZ
-        (ThreadContext context
-
-            ) {
-        return context.runtime.newFloat(jz);
-        }
-
-        /**
-         *
-         * @param context ThreadContext
-         * @param other IRubyObject
-         * @return x IRubyObject
-         */
-        @JRubyMethod(name = "x=")
-
-        public IRubyObject setX
-        (ThreadContext context, IRubyObject other
-
-            ) {
-        if (other instanceof RubyFloat) {
-                jx = ((RubyFloat) other).getValue();
-            } else {
-                jx = ((RubyFixnum) other).getDoubleValue();
-            }
-            return other;
-        }
-
-        /**
-         *
-         * @param context ThreadContext
-         * @param other IRubyObject
-         * @return y IRubyObject
-         */
-        @JRubyMethod(name = "y=")
-
-        public IRubyObject setY
-        (ThreadContext context, IRubyObject other
-
-            ) {
-        if (other instanceof RubyFloat) {
-                jy = ((RubyFloat) other).getValue();
-            } else {
-                jy = ((RubyFixnum) other).getDoubleValue();
-            }
-            return other;
-        }
-
-        /**
-         *
-         * @param context ThreadContext
-         * @param other IRubyObject
-         * @return z IRubyObject
-         */
-        @JRubyMethod(name = "z=")
-        public IRubyObject setZ
-        (ThreadContext context, IRubyObject other
-
-            ) {
-        if (other instanceof RubyFloat) {
-                jz = ((RubyFloat) other).getValue();
-            } else {
-                jz = ((RubyFixnum) other).getDoubleValue();
-            }
-            return other;
-        }
-
-        /**
-         *
-         * @param context ThreadContext
-         * @param key as symbol
-         * @return value float
-         */
-        @JRubyMethod(name = "[]", required = 1)
-
-        public IRubyObject aref
-        (ThreadContext context, IRubyObject key
-
-            ) {
-        Ruby runtime = context.runtime;
-            if (key instanceof RubySymbol) {
-                if (key == RubySymbol.newSymbol(runtime, "x")) {
-                    return runtime.newFloat(jx);
-                } else if (key == RubySymbol.newSymbol(runtime, "y")) {
-                    return runtime.newFloat(jy);
-                } else if (key == RubySymbol.newSymbol(runtime, "z")) {
-                    return runtime.newFloat(jz);
-                } else {
-                    throw runtime.newIndexError("invalid key");
-                }
-            } else {
-                throw runtime.newIndexError("invalid key");
-            }
-        }
-
-        /**
-         * @param context ThreadContext
-         * @param key as symbol
-         * @param value as float
-         * @return value float
-         */
-        @JRubyMethod(name = "[]=")
-
-        public IRubyObject aset
-        (ThreadContext context, IRubyObject key
-        , IRubyObject value
-
-            ) {
-        Ruby runtime = context.runtime;
-            if (key instanceof RubySymbol) {
-                if (key == RubySymbol.newSymbol(runtime, "x")) {
-                    jx = (value instanceof RubyFloat)
-                            ? ((RubyFloat) value).getValue() : ((RubyFixnum) value).getDoubleValue();
-                } else if (key == RubySymbol.newSymbol(runtime, "y")) {
-                    jy = (value instanceof RubyFloat)
-                            ? ((RubyFloat) value).getValue() : ((RubyFixnum) value).getDoubleValue();
-                } else if (key == RubySymbol.newSymbol(runtime, "z")) {
-                    jz = (value instanceof RubyFloat)
-                            ? ((RubyFloat) value).getValue() : ((RubyFixnum) value).getDoubleValue();
-                } else {
-                    throw runtime.newIndexError("invalid key");
-                }
-            } else {
-                throw runtime.newIndexError("invalid key");
-            }
-            return value;
-        }
-
-        /**
-         *
-         * @param context ThreadContext
-         * @param other IRubyObject
-         * @return distance float
-         */
-        @JRubyMethod(name = "dist", required = 1)
-
-        public IRubyObject dist
-        (ThreadContext context, IRubyObject other
-
-            ) {
-        Vec3 b = null;
-            if (other instanceof Vec3) {
-                b = (Vec3) other.toJava(Vec3.class);
-            } else {
-                throw context.runtime.newTypeError("argument should be Vec3D");
-            }
-            double result = Math.sqrt((jx - b.jx) * (jx - b.jx) + (jy - b.jy) * (jy - b.jy) + (jz - b.jz) * (jz - b.jz));
-            return context.runtime.newFloat(result);
-        }
-
-        /**
-         *
-         * @param context ThreadContext
-         * @param other IRubyObject
-         * @return distance squared float
-         */
-        @JRubyMethod(name = "dist_squared", required = 1)
-
-        public IRubyObject dist_squared
-        (ThreadContext context, IRubyObject other
-
-            ) {
-        Vec3 b = null;
-            if (other instanceof Vec3) {
-                b = (Vec3) other.toJava(Vec3.class);
-            } else {
-                throw context.runtime.newTypeError("argument should be Vec3D");
-            }
-            double result = (jx - b.jx) * (jx - b.jx) + (jy - b.jy) * (jy - b.jy) + (jz - b.jz) * (jz - b.jz);
-            return context.runtime.newFloat(result);
-        }
-
-        /**
-         *
-         *
-         * @param context ThreadContext
-         * @param other IRubyObject
-         * @return cross product IRubyObject
-         */
-        @JRubyMethod(name = "cross", required = 1)
-
-        public IRubyObject cross
-        (ThreadContext context, IRubyObject other
-
-            ) {
-        Ruby runtime = context.runtime;
-            Vec3 vec = null;
-            if (other instanceof Vec3) {
-                vec = (Vec3) other.toJava(Vec3.class);
-            } else {
-                throw runtime.newTypeError("argument should be Vec3D");
-            }
-            return Vec3.rbNew(context, other.getMetaClass(), new IRubyObject[]{
-                runtime.newFloat(jy * vec.jz - jz * vec.jy),
-                runtime.newFloat(jz * vec.jx - jx * vec.jz),
-                runtime.newFloat(jx * vec.jy - jy * vec.jx)
-            }
-            );
-        }
-
-        /**
-         *
-         * @param context ThreadContext
-         * @param other IRubyObject
-         * @return dot product IRubyObject
-         */
-        @JRubyMethod(name = "dot", required = 1)
-
-        public IRubyObject dot
-        (ThreadContext context, IRubyObject other
-
-            ) {
-        Ruby runtime = context.runtime;
-            Vec3 b = null;
-            if (other instanceof Vec3) {
-                b = (Vec3) other.toJava(Vec3.class);
-            } else {
-                throw runtime.newTypeError("argument should be Vec3D");
-            }
-            return runtime.newFloat(jx * b.jx + jy * b.jy + jz * b.jz);
-        }
-
-        /**
-         *
-         * @param context ThreadContext
-         * @param other IRubyObject
-         * @return new Vec3 object (ruby)
-         */
-        @JRubyMethod(name = "+", required = 1)
-
-        public IRubyObject op_add
-        (ThreadContext context, IRubyObject other
-
-            ) {
-        Ruby runtime = context.runtime;
-            Vec3 b = (Vec3) other.toJava(Vec3.class);
-            return Vec3.rbNew(context, other.getMetaClass(), new IRubyObject[]{
-                runtime.newFloat(jx + b.jx),
-                runtime.newFloat(jy + b.jy),
-                runtime.newFloat(jz + b.jz)});
-        }
-
-        /**
-         *
-         * @param context ThreadContext
-         * @param other IRubyObject
-         * @return new Vec3 object (ruby)
-         */
-        @JRubyMethod(name = "-")
-
-        public IRubyObject op_sub
-        (ThreadContext context, IRubyObject other
-
-            ) {
-        Ruby runtime = context.runtime;
-            Vec3 b = null;
-            if (other instanceof Vec3) {
-                b = (Vec3) other.toJava(Vec3.class);
-            } else {
-                throw runtime.newTypeError("argument should be Vec3D");
-            }
-            return Vec3.rbNew(context, other.getMetaClass(), new IRubyObject[]{
-                runtime.newFloat(jx - b.jx),
-                runtime.newFloat(jy - b.jy),
-                runtime.newFloat(jz - b.jz)});
-        }
-
-        /**
-         *
-         * @param context ThreadContext
-         * @param scalar IRubyObject
-         * @return new Vec3 object (ruby)
-         */
-        @JRubyMethod(name = "*", required = 1)
-
-        public IRubyObject op_mul
-        (ThreadContext context, IRubyObject scalar
-
-            ) {
-        Ruby runtime = context.runtime;
-            double multi = (scalar instanceof RubyFloat)
-                    ? ((RubyFloat) scalar).getValue() : ((RubyFixnum) scalar).getDoubleValue();
-            return Vec3.rbNew(context, this.getMetaClass(), new IRubyObject[]{
-                runtime.newFloat(jx * multi),
-                runtime.newFloat(jy * multi),
-                runtime.newFloat(jz * multi)});
-        }
-
-        /**
-         *
-         * @param context ThreadContext
-         * @param scalar IRubyObject
-         * @return new Vec3 object (ruby)
-         */
-        @JRubyMethod(name = "/", required = 1)
-
-        public IRubyObject op_div
-        (ThreadContext context, IRubyObject scalar
-
-            ) {
-        Ruby runtime = context.runtime;
-            double divisor = (scalar instanceof RubyFloat)
-                    ? ((RubyFloat) scalar).getValue() : ((RubyFixnum) scalar).getDoubleValue();
-            if (Math.abs(divisor) < Vec3.EPSILON) {
-                return this;
-            }
-            return Vec3.rbNew(context, this.getMetaClass(), new IRubyObject[]{
-                runtime.newFloat(jx / divisor),
-                runtime.newFloat(jy / divisor),
-                runtime.newFloat(jz / divisor)});
-        }
-
-        /**
-         *
-         * @param context ThreadContext
-         * @return magnitude squared IRubyObject
-         */
-        @JRubyMethod(name = "mag_squared")
-
-        public IRubyObject mag_squared
-        (ThreadContext context
-
-            ) {
-        return context.runtime.newFloat(jx * jx + jy * jy + jz * jz);
-        }
-
-        /**
-         *
-         * @param context ThreadContext
-         * @return magnitude IRubyObject
-         */
-        @JRubyMethod(name = "mag")
-
-        public IRubyObject mag
-        (ThreadContext context
-
-            ) {
-        return context.runtime.newFloat(Math.sqrt(jx * jx + jy * jy + jz * jz));
-        }
-
-        /**
-         * Call yield if block given, do nothing if yield == false else set_mag
-         * to given scalar
-         *
-         * @param context ThreadContext
-         * @param scalar double value to set
-         * @param block should return a boolean (optional)
-         * @return magnitude IRubyObject
-         */
-        @JRubyMethod(name = "set_mag")
-
-        public IRubyObject set_mag
-        (ThreadContext context, IRubyObject scalar
-        , Block block
-
-            ) {
-        if (block.isGiven()) {
-                if (!(boolean) block.yield(context, scalar).toJava(Boolean.class)) {
-                    return this;
-                }
-            }
-            double new_mag = (scalar instanceof RubyFloat)
-                    ? ((RubyFloat) scalar).getValue() : ((RubyFixnum) scalar).getDoubleValue();
-            double current = Math.sqrt(jx * jx + jy * jy + jz * jz);
-            if (current > EPSILON) {
-                jx *= new_mag / current;
-                jy *= new_mag / current;
-                jz *= new_mag / current;
-            }
-            return this;
-        }
-
-        /**
-         *
-         * @param context ThreadContext
-         * @return this as a ruby object
-         */
-        @JRubyMethod(name = "normalize!")
-
-        public IRubyObject normalize_bang
-        (ThreadContext context
-
-            ) {
-        if (Math.abs(jx) < EPSILON && Math.abs(jy) < EPSILON && Math.abs(jz) < EPSILON) {
-                return this;
-            }
-            double mag = Math.sqrt(jx * jx + jy * jy + jz * jz);
-            jx /= mag;
-            jy /= mag;
-            jz /= mag;
-            return this;
-        }
-
-        /**
-         *
-         * @param context ThreadContext
-         * @return new normalized Vec3D object (ruby)
-         */
-        @JRubyMethod(name = "normalize")
-
-        public IRubyObject normalize
-        (ThreadContext context
-
-            ) {
-        Ruby runtime = context.runtime;
-            double mag = Math.sqrt(jx * jx + jy * jy + jz * jz);
-            if (mag < EPSILON) {
-                return Vec3.rbNew(context, this.getMetaClass(), new IRubyObject[]{
-                    runtime.newFloat(jx),
-                    runtime.newFloat(jy),
-                    runtime.newFloat(jz)});
-            }
-            return Vec3.rbNew(context, this.getMetaClass(), new IRubyObject[]{
-                runtime.newFloat(jx / mag),
-                runtime.newFloat(jy / mag),
-                runtime.newFloat(jz / mag)});
-        }
-
-        /**
-         * Example of a regular ruby class method
-         *
-         * @param context ThreadContext
-         * @param klazz IRubyObject
-         * @return new random Vec3D object (ruby)
-         */
-        @JRubyMethod(name = "random", meta = true)
-
-        public static IRubyObject random_direction
-        (ThreadContext context, IRubyObject klazz
-
-            ) {
-        Ruby runtime = context.runtime;
-            double angle = Math.random() * Math.PI * 2;
-            double vz = Math.random() * 2 - 1;
-            double vx = Math.sqrt(1 - vz * vz) * Math.cos(angle);
-            double vy = Math.sqrt(1 - vz * vz) * Math.sin(angle);
-
-            return Vec3.rbNew(context, klazz, new IRubyObject[]{
-                runtime.newFloat(vx),
-                runtime.newFloat(vy),
-                runtime.newFloat(vz)});
-        }
-
-        /**
-         *
-         * @param context ThreadContext
-         * @param other IRubyObject another Vec3D
-         * @return angle IRubyObject in radians
-         */
-        @JRubyMethod(name = "angle_between")
-
-        public IRubyObject angleBetween
-        (ThreadContext context, IRubyObject other
-
-            ) {
-        Ruby runtime = context.runtime;
-            Vec3 vec = (Vec3) other.toJava(Vec3.class);
-            // We get NaN if we pass in a zero vector which can cause problems
-            // Zero seems like a reasonable angle between a (0,0,0) vector and something else
-            if (jx == 0 && jy == 0 && jz == 0) {
-                return runtime.newFloat(0.0);
-            }
-            if (vec.jx == 0 && vec.jy == 0 && vec.jz == 0) {
-                return runtime.newFloat(0.0);
-            }
-
-            double dot = jx * vec.jx + jy * vec.jy + jz * vec.jz;
-            double v1mag = Math.sqrt(jx * jx + jy * jy + jz * jz);
-            double v2mag = Math.sqrt(vec.jx * vec.jx + vec.jy * vec.jy + vec.jz * vec.jz);
-            // This should be a number between -1 and 1, since it's "normalized"
-            double amt = dot / (v1mag * v2mag);
-            if (amt <= -1) {
-                return runtime.newFloat(Math.PI);
-            } else if (amt >= 1) {
-                return runtime.newFloat(0.0);
-            }
-            return runtime.newFloat(Math.acos(amt));
-        }
-
-        /**
-         *
-         * @param context ThreadContext
-         * @return IRubyObject copy
-         */
-        @JRubyMethod(name = {"copy", "dup"})
-
-        public IRubyObject copy
-        (ThreadContext context
-
-            ) {
-        Ruby runtime = context.runtime;
-            return Vec3.rbNew(context, this.getMetaClass(), new IRubyObject[]{
-                runtime.newFloat(jx),
-                runtime.newFloat(jy),
-                runtime.newFloat(jz)});
-        }
-
-        /**
-         *
-         * @param context ThreadContext
-         * @return IRubyObject array of float
-         */
-        @JRubyMethod(name = "to_a")
-
-        public IRubyObject toArray
-        (ThreadContext context
-
-            ) {
-        Ruby runtime = context.runtime;
-            return RubyArray.newArray(context.runtime, new IRubyObject[]{
-                runtime.newFloat(jx),
-                runtime.newFloat(jy),
-                runtime.newFloat(jz)});
-        }
-
-        /**
-         * To vertex
-         *
-         * @param context ThreadContext
-         * @param object IRubyObject vertex renderer
-         */
-        @JRubyMethod(name = "to_vertex")
-
-        public void toVertex
-        (ThreadContext context, IRubyObject object
-
-            ) {
-        JRender renderer = (JRender) object.toJava(JRender.class);
-            renderer.vertex(jx, jy, jz);
-        }
-
-        /**
-         * To curve vertex
-         *
-         * @param context ThreadContext
-         * @param object IRubyObject vertex renderer
-         */
-        @JRubyMethod(name = "to_curve_vertex")
-
-        public void toCurveVertex
-        (ThreadContext context, IRubyObject object
-
-            ) {
-        JRender renderer = (JRender) object.toJava(JRender.class);
-            renderer.curveVertex(jx, jy, jz);
-        }
-
-        /**
-         * Sends this Vec3D as a processing vertex uv
-         *
-         * @param context ThreadContext
-         * @param args IRubyObject[]
-         */
-        @JRubyMethod(name = "to_vertex_uv", rest = true)
-
-        public void toVertexUV
-        (ThreadContext context, IRubyObject[] args
-
-            ) {
-        int count = Arity.checkArgumentCount(context.runtime, args, Arity.OPTIONAL.getValue(), 3);
-            double u = 0;
-            double v = 0;
-            if (count == 3) {
-                u = (args[1] instanceof RubyFloat)
-                        ? ((RubyFloat) args[1]).getValue() : ((RubyFixnum) args[1]).getDoubleValue();
-                v = (args[2] instanceof RubyFloat)
-                        ? ((RubyFloat) args[2]).getValue() : ((RubyFixnum) args[2]).getDoubleValue();
-            }
-            if (count == 2) {
-                Vec2 texture = (Vec2) args[1].toJava(Vec2.class);
-                u = texture.javax();
-                v = texture.javay();
-            }
-            JRender renderer = (JRender) args[0].toJava(JRender.class);
-            renderer.vertex(jx, jy, jz, u, v);
-        }
-
-        /**
-         * Sends this Vec3D as a processing normal
-         *
-         * @param context ThreadContext
-         * @param object IRubyObject vertex renderer
-         */
-        @JRubyMethod(name = "to_normal")
-
-        public void toNormal
-        (ThreadContext context, IRubyObject object
-
-            ) {
-        JRender renderer = (JRender) object.toJava(JRender.class);
-            renderer.normal(jx, jy, jz);
-        }
-
-        /**
-         * For jruby-9000 we alias to inspect
-         *
-         * @param context ThreadContext
-         * @return IRubyObject to_s
-         */
-        @JRubyMethod(name = {"to_s", "inspect"})
-
-        public IRubyObject to_s
-        (ThreadContext context
-
-            ) {
-        return context.runtime.newString(String.format("Vec3D(x = %4.4f, y = %4.4f, z = %4.4f)", jx, jy, jz));
-        }
-
-        /**
-         * Java hash
-         *
-         * @return hash int
-         */
-        @Override
-        public int hashCode
-
-            () {
-        int hash = 7;
-            hash = 97 * hash + (int) (Double.doubleToLongBits(this.jx) ^ (Double.doubleToLongBits(this.jx) >>> 32));
-            hash = 97 * hash + (int) (Double.doubleToLongBits(this.jy) ^ (Double.doubleToLongBits(this.jy) >>> 32));
-            hash = 97 * hash + (int) (Double.doubleToLongBits(this.jz) ^ (Double.doubleToLongBits(this.jz) >>> 32));
-            return hash;
-        }
-
-        /**
-         * Java Equals
-         *
-         * @param obj Object
-         * @return result boolean
-         */
-        @Override
-        public boolean equals
-        (Object obj
-
-            ) {
-        if (obj == this) {
-                return true;
-            }
-            if (obj instanceof Vec3) {
-                final Vec3 other = (Vec3) obj;
-                if ((Double.compare(jx, (Double) other.jx) == 0)
-                        && (Double.compare(jy, (Double) other.jy) == 0)
-                        && (Double.compare(jz, (Double) other.jz) == 0)) {
-                    return true;
-                }
-
-            }
-            return false;
-        }
-
-        /**
-         *
-         * @param context ThreadContext
-         * @param other IRubyObject
-         * @return result IRubyObject as boolean
-         */
-        @JRubyMethod(name = "eql?", required = 1)
-
-        public IRubyObject eql_p
-        (ThreadContext context, IRubyObject other
-
-            ) {
-        Ruby runtime = context.runtime;
-            if (other == this) {
-                return runtime.newBoolean(true);
-            }
-            if (other instanceof Vec3) {
-                Vec3 v = (Vec3) other.toJava(Vec3.class);
-                if ((Double.compare(jx, (Double) v.jx) == 0)
-                        && (Double.compare(jy, (Double) v.jy) == 0)
-                        && (Double.compare(jz, (Double) v.jz) == 0)) {
-                    return runtime.newBoolean(true);
-                }
-
-            }
-            return runtime.newBoolean(false);
-        }
-
-        /**
-         *
-         * @param context ThreadContext
-         * @param other IRubyObject
-         * @return result IRubyObject as boolean
-         */
-        @JRubyMethod(name = "==", required = 1)
-
-        @Override
-        public IRubyObject op_equal
-        (ThreadContext context, IRubyObject other
-
-            ) {
-        Ruby runtime = context.runtime;
-            if (other == this) {
-                return runtime.newBoolean(true);
-            }
-            if (other instanceof Vec3) {
-                Vec3 v = (Vec3) other.toJava(Vec3.class);
-                double diff = jx - v.jx;
-                if ((diff < 0 ? -diff : diff) > Vec3.EPSILON) {
-                    return runtime.newBoolean(false);
-                }
-                diff = jy - v.jy;
-                if ((diff < 0 ? -diff : diff) > Vec3.EPSILON) {
-                    return runtime.newBoolean(false);
-                }
-                diff = jz - v.jz;
-                return runtime.newBoolean((diff < 0 ? -diff : diff) < Vec3.EPSILON);
-            }
-            return runtime.newBoolean(false);
         }
     }
+
+    /**
+     *
+     * @param context ThreadContext
+     * @return x IRubyObject
+     */
+    @JRubyMethod(name = "x")
+
+    public IRubyObject getX(ThreadContext context) {
+        return context.runtime.newFloat(jx);
+    }
+
+    /**
+     *
+     * @param context ThreadContext
+     * @return y IRubyObject
+     */
+    @JRubyMethod(name = "y")
+    public IRubyObject getY(ThreadContext context) {
+        return context.runtime.newFloat(jy);
+    }
+
+    /**
+     *
+     * @param context ThreadContext
+     * @return z IRubyObject
+     */
+    @JRubyMethod(name = "z")
+    public IRubyObject getZ(ThreadContext context
+    ) {
+        return context.runtime.newFloat(jz);
+    }
+
+    /**
+     *
+     * @param context ThreadContext
+     * @param other IRubyObject
+     * @return x IRubyObject
+     */
+    @JRubyMethod(name = "x=")
+    public IRubyObject setX(ThreadContext context, IRubyObject other) {
+        if (other instanceof RubyFloat) {
+            jx = ((RubyFloat) other).getValue();
+        } else {
+            jx = ((RubyFixnum) other).getDoubleValue();
+        }
+        return other;
+    }
+
+    /**
+     *
+     * @param context ThreadContext
+     * @param other IRubyObject
+     * @return y IRubyObject
+     */
+    @JRubyMethod(name = "y=")
+    public IRubyObject setY(ThreadContext context, IRubyObject other) {
+        if (other instanceof RubyFloat) {
+            jy = ((RubyFloat) other).getValue();
+        } else {
+            jy = ((RubyFixnum) other).getDoubleValue();
+        }
+        return other;
+    }
+
+    /**
+     *
+     * @param context ThreadContext
+     * @param other IRubyObject
+     * @return z IRubyObject
+     */
+    @JRubyMethod(name = "z=")
+    public IRubyObject setZ(ThreadContext context, IRubyObject other) {
+        if (other instanceof RubyFloat) {
+            jz = ((RubyFloat) other).getValue();
+        } else {
+            jz = ((RubyFixnum) other).getDoubleValue();
+        }
+        return other;
+    }
+
+    /**
+     *
+     * @param context ThreadContext
+     * @param key as symbol
+     * @return value float
+     */
+    @JRubyMethod(name = "[]", required = 1)
+    public IRubyObject aref(ThreadContext context, IRubyObject key) {
+        Ruby runtime = context.runtime;
+        if (key instanceof RubySymbol) {
+            if (key == RubySymbol.newSymbol(runtime, "x")) {
+                return runtime.newFloat(jx);
+            } else if (key == RubySymbol.newSymbol(runtime, "y")) {
+                return runtime.newFloat(jy);
+            } else if (key == RubySymbol.newSymbol(runtime, "z")) {
+                return runtime.newFloat(jz);
+            } else {
+                throw runtime.newIndexError("invalid key");
+            }
+        } else {
+            throw runtime.newIndexError("invalid key");
+        }
+    }
+
+    /**
+     * @param context ThreadContext
+     * @param key as symbol
+     * @param value as float
+     * @return value float
+     */
+    @JRubyMethod(name = "[]=")
+    public IRubyObject aset(ThreadContext context, IRubyObject key, IRubyObject value) {
+        Ruby runtime = context.runtime;
+        if (key instanceof RubySymbol) {
+            if (key == RubySymbol.newSymbol(runtime, "x")) {
+                jx = (value instanceof RubyFloat)
+                        ? ((RubyFloat) value).getValue() : ((RubyFixnum) value).getDoubleValue();
+            } else if (key == RubySymbol.newSymbol(runtime, "y")) {
+                jy = (value instanceof RubyFloat)
+                        ? ((RubyFloat) value).getValue() : ((RubyFixnum) value).getDoubleValue();
+            } else if (key == RubySymbol.newSymbol(runtime, "z")) {
+                jz = (value instanceof RubyFloat)
+                        ? ((RubyFloat) value).getValue() : ((RubyFixnum) value).getDoubleValue();
+            } else {
+                throw runtime.newIndexError("invalid key");
+            }
+        } else {
+            throw runtime.newIndexError("invalid key");
+        }
+        return value;
+    }
+
+    /**
+     *
+     * @param context ThreadContext
+     * @param other IRubyObject
+     * @return distance float
+     */
+    @JRubyMethod(name = "dist", required = 1)
+
+    public IRubyObject dist(ThreadContext context, IRubyObject other) {
+        Vec3 b = null;
+        if (other instanceof Vec3) {
+            b = (Vec3) other.toJava(Vec3.class);
+        } else {
+            throw context.runtime.newTypeError("argument should be Vec3D");
+        }
+        double result = Math.sqrt((jx - b.jx) * (jx - b.jx) + (jy - b.jy) * (jy - b.jy) + (jz - b.jz) * (jz - b.jz));
+        return context.runtime.newFloat(result);
+    }
+
+    /**
+     *
+     * @param context ThreadContext
+     * @param other IRubyObject
+     * @return distance squared float
+     */
+    @JRubyMethod(name = "dist_squared", required = 1)
+
+    public IRubyObject dist_squared(ThreadContext context, IRubyObject other) {
+        Vec3 b = null;
+        if (other instanceof Vec3) {
+            b = (Vec3) other.toJava(Vec3.class);
+        } else {
+            throw context.runtime.newTypeError("argument should be Vec3D");
+        }
+        double result = (jx - b.jx) * (jx - b.jx) + (jy - b.jy) * (jy - b.jy) + (jz - b.jz) * (jz - b.jz);
+        return context.runtime.newFloat(result);
+    }
+
+    /**
+     *
+     *
+     * @param context ThreadContext
+     * @param other IRubyObject
+     * @return cross product IRubyObject
+     */
+    @JRubyMethod(name = "cross", required = 1)
+
+    public IRubyObject cross(ThreadContext context, IRubyObject other) {
+        Ruby runtime = context.runtime;
+        Vec3 vec = null;
+        if (other instanceof Vec3) {
+            vec = (Vec3) other.toJava(Vec3.class);
+        } else {
+            throw runtime.newTypeError("argument should be Vec3D");
+        }
+        return Vec3.rbNew(context, other.getMetaClass(), new IRubyObject[]{
+            runtime.newFloat(jy * vec.jz - jz * vec.jy),
+            runtime.newFloat(jz * vec.jx - jx * vec.jz),
+            runtime.newFloat(jx * vec.jy - jy * vec.jx)
+        }
+        );
+    }
+
+    /**
+     *
+     * @param context ThreadContext
+     * @param other IRubyObject
+     * @return dot product IRubyObject
+     */
+    @JRubyMethod(name = "dot", required = 1)
+
+    public IRubyObject dot(ThreadContext context, IRubyObject other) {
+        Ruby runtime = context.runtime;
+        Vec3 b = null;
+        if (other instanceof Vec3) {
+            b = (Vec3) other.toJava(Vec3.class);
+        } else {
+            throw runtime.newTypeError("argument should be Vec3D");
+        }
+        return runtime.newFloat(jx * b.jx + jy * b.jy + jz * b.jz);
+    }
+
+    /**
+     *
+     * @param context ThreadContext
+     * @param other IRubyObject
+     * @return new Vec3 object (ruby)
+     */
+    @JRubyMethod(name = "+", required = 1)
+
+    public IRubyObject op_add(ThreadContext context, IRubyObject other) {
+        Ruby runtime = context.runtime;
+        Vec3 b = (Vec3) other.toJava(Vec3.class);
+        return Vec3.rbNew(context, other.getMetaClass(), new IRubyObject[]{
+            runtime.newFloat(jx + b.jx),
+            runtime.newFloat(jy + b.jy),
+            runtime.newFloat(jz + b.jz)});
+    }
+
+    /**
+     *
+     * @param context ThreadContext
+     * @param other IRubyObject
+     * @return new Vec3 object (ruby)
+     */
+    @JRubyMethod(name = "-")
+    public IRubyObject op_sub(ThreadContext context, IRubyObject other) {
+        Ruby runtime = context.runtime;
+        Vec3 b = null;
+        if (other instanceof Vec3) {
+            b = (Vec3) other.toJava(Vec3.class);
+        } else {
+            throw runtime.newTypeError("argument should be Vec3D");
+        }
+        return Vec3.rbNew(context, other.getMetaClass(), new IRubyObject[]{
+            runtime.newFloat(jx - b.jx),
+            runtime.newFloat(jy - b.jy),
+            runtime.newFloat(jz - b.jz)});
+    }
+
+    /**
+     *
+     * @param context ThreadContext
+     * @param scalar IRubyObject
+     * @return new Vec3 object (ruby)
+     */
+    @JRubyMethod(name = "*", required = 1)
+    public IRubyObject op_mul(ThreadContext context, IRubyObject scalar) {
+        Ruby runtime = context.runtime;
+        double multi = (scalar instanceof RubyFloat)
+                ? ((RubyFloat) scalar).getValue() : ((RubyFixnum) scalar).getDoubleValue();
+        return Vec3.rbNew(context, this.getMetaClass(), new IRubyObject[]{
+            runtime.newFloat(jx * multi),
+            runtime.newFloat(jy * multi),
+            runtime.newFloat(jz * multi)});
+    }
+
+    /**
+     *
+     * @param context ThreadContext
+     * @param scalar IRubyObject
+     * @return new Vec3 object (ruby)
+     */
+    @JRubyMethod(name = "/", required = 1)
+    public IRubyObject op_div(ThreadContext context, IRubyObject scalar) {
+        Ruby runtime = context.runtime;
+        double divisor = (scalar instanceof RubyFloat)
+                ? ((RubyFloat) scalar).getValue() : ((RubyFixnum) scalar).getDoubleValue();
+        if (Math.abs(divisor) < Vec3.EPSILON) {
+            return this;
+        }
+        return Vec3.rbNew(context, this.getMetaClass(), new IRubyObject[]{
+            runtime.newFloat(jx / divisor),
+            runtime.newFloat(jy / divisor),
+            runtime.newFloat(jz / divisor)});
+    }
+
+    /**
+     *
+     * @param context ThreadContext
+     * @return magnitude squared IRubyObject
+     */
+    @JRubyMethod(name = "mag_squared")
+    public IRubyObject mag_squared(ThreadContext context) {
+        return context.runtime.newFloat(jx * jx + jy * jy + jz * jz);
+    }
+
+    /**
+     *
+     * @param context ThreadContext
+     * @return magnitude IRubyObject
+     */
+    @JRubyMethod(name = "mag")
+    public IRubyObject mag(ThreadContext context) {
+        return context.runtime.newFloat(Math.sqrt(jx * jx + jy * jy + jz * jz));
+    }
+
+    /**
+     * Call yield if block given, do nothing if yield == false else set_mag to
+     * given scalar
+     *
+     * @param context ThreadContext
+     * @param scalar double value to set
+     * @param block should return a boolean (optional)
+     * @return magnitude IRubyObject
+     */
+    @JRubyMethod(name = "set_mag")
+    public IRubyObject set_mag(ThreadContext context, IRubyObject scalar, Block block) {
+        if (block.isGiven()) {
+            if (!(boolean) block.yield(context, scalar).toJava(Boolean.class)) {
+                return this;
+            }
+        }
+        double new_mag = (scalar instanceof RubyFloat)
+                ? ((RubyFloat) scalar).getValue() : ((RubyFixnum) scalar).getDoubleValue();
+        double current = Math.sqrt(jx * jx + jy * jy + jz * jz);
+        if (current > EPSILON) {
+            jx *= new_mag / current;
+            jy *= new_mag / current;
+            jz *= new_mag / current;
+        }
+        return this;
+    }
+
+    /**
+     *
+     * @param context ThreadContext
+     * @return this as a ruby object
+     */
+    @JRubyMethod(name = "normalize!")
+    public IRubyObject normalize_bang(ThreadContext context) {
+        if (Math.abs(jx) < EPSILON && Math.abs(jy) < EPSILON && Math.abs(jz) < EPSILON) {
+            return this;
+        }
+        double mag = Math.sqrt(jx * jx + jy * jy + jz * jz);
+        jx /= mag;
+        jy /= mag;
+        jz /= mag;
+        return this;
+    }
+
+    /**
+     *
+     * @param context ThreadContext
+     * @return new normalized Vec3D object (ruby)
+     */
+    @JRubyMethod(name = "normalize")
+    public IRubyObject normalize(ThreadContext context) {
+        Ruby runtime = context.runtime;
+        double mag = Math.sqrt(jx * jx + jy * jy + jz * jz);
+        if (mag < EPSILON) {
+            return Vec3.rbNew(context, this.getMetaClass(), new IRubyObject[]{
+                runtime.newFloat(jx),
+                runtime.newFloat(jy),
+                runtime.newFloat(jz)});
+        }
+        return Vec3.rbNew(context, this.getMetaClass(), new IRubyObject[]{
+            runtime.newFloat(jx / mag),
+            runtime.newFloat(jy / mag),
+            runtime.newFloat(jz / mag)});
+    }
+
+    /**
+     * Example of a regular ruby class method
+     *
+     * @param context ThreadContext
+     * @param klazz IRubyObject
+     * @return new random Vec3D object (ruby)
+     */
+    @JRubyMethod(name = "random", meta = true)
+    public static IRubyObject random_direction(ThreadContext context, IRubyObject klazz) {
+        Ruby runtime = context.runtime;
+        double angle = Math.random() * Math.PI * 2;
+        double vz = Math.random() * 2 - 1;
+        double vx = Math.sqrt(1 - vz * vz) * Math.cos(angle);
+        double vy = Math.sqrt(1 - vz * vz) * Math.sin(angle);
+
+        return Vec3.rbNew(context, klazz, new IRubyObject[]{
+            runtime.newFloat(vx),
+            runtime.newFloat(vy),
+            runtime.newFloat(vz)});
+    }
+
+    /**
+     *
+     * @param context ThreadContext
+     * @param other IRubyObject another Vec3D
+     * @return angle IRubyObject in radians
+     */
+    @JRubyMethod(name = "angle_between")
+    public IRubyObject angleBetween(ThreadContext context, IRubyObject other) {
+        Ruby runtime = context.runtime;
+        Vec3 vec = (Vec3) other.toJava(Vec3.class);
+        // We get NaN if we pass in a zero vector which can cause problems
+        // Zero seems like a reasonable angle between a (0,0,0) vector and something else
+        if (jx == 0 && jy == 0 && jz == 0) {
+            return runtime.newFloat(0.0);
+        }
+        if (vec.jx == 0 && vec.jy == 0 && vec.jz == 0) {
+            return runtime.newFloat(0.0);
+        }
+
+        double dot = jx * vec.jx + jy * vec.jy + jz * vec.jz;
+        double v1mag = Math.sqrt(jx * jx + jy * jy + jz * jz);
+        double v2mag = Math.sqrt(vec.jx * vec.jx + vec.jy * vec.jy + vec.jz * vec.jz);
+        // This should be a number between -1 and 1, since it's "normalized"
+        double amt = dot / (v1mag * v2mag);
+        if (amt <= -1) {
+            return runtime.newFloat(Math.PI);
+        } else if (amt >= 1) {
+            return runtime.newFloat(0.0);
+        }
+        return runtime.newFloat(Math.acos(amt));
+    }
+
+    /**
+     *
+     * @param context ThreadContext
+     * @return IRubyObject copy
+     */
+    @JRubyMethod(name = {"copy", "dup"})
+    public IRubyObject copy(ThreadContext context) {
+        Ruby runtime = context.runtime;
+        return Vec3.rbNew(context, this.getMetaClass(), new IRubyObject[]{
+            runtime.newFloat(jx),
+            runtime.newFloat(jy),
+            runtime.newFloat(jz)});
+    }
+
+    /**
+     *
+     * @param context ThreadContext
+     * @return IRubyObject array of float
+     */
+    @JRubyMethod(name = "to_a")
+    public IRubyObject toArray(ThreadContext context) {
+        Ruby runtime = context.runtime;
+        return RubyArray.newArray(context.runtime, new IRubyObject[]{
+            runtime.newFloat(jx),
+            runtime.newFloat(jy),
+            runtime.newFloat(jz)});
+    }
+
+    /**
+     * To vertex
+     *
+     * @param context ThreadContext
+     * @param object IRubyObject vertex renderer
+     */
+    @JRubyMethod(name = "to_vertex")
+    public void toVertex(ThreadContext context, IRubyObject object) {
+        JRender renderer = (JRender) object.toJava(JRender.class);
+        renderer.vertex(jx, jy, jz);
+    }
+
+    /**
+     * To curve vertex
+     *
+     * @param context ThreadContext
+     * @param object IRubyObject vertex renderer
+     */
+    @JRubyMethod(name = "to_curve_vertex")
+    public void toCurveVertex(ThreadContext context, IRubyObject object) {
+        JRender renderer = (JRender) object.toJava(JRender.class);
+        renderer.curveVertex(jx, jy, jz);
+    }
+
+    /**
+     * Sends this Vec3D as a processing vertex uv
+     *
+     * @param context ThreadContext
+     * @param args IRubyObject[]
+     */
+    @JRubyMethod(name = "to_vertex_uv", rest = true)
+    public void toVertexUV(ThreadContext context, IRubyObject[] args) {
+        int count = Arity.checkArgumentCount(context.runtime, args, Arity.OPTIONAL.getValue(), 3);
+        double u = 0;
+        double v = 0;
+        if (count == 3) {
+            u = (args[1] instanceof RubyFloat)
+                    ? ((RubyFloat) args[1]).getValue() : ((RubyFixnum) args[1]).getDoubleValue();
+            v = (args[2] instanceof RubyFloat)
+                    ? ((RubyFloat) args[2]).getValue() : ((RubyFixnum) args[2]).getDoubleValue();
+        }
+        if (count == 2) {
+            Vec2 texture = (Vec2) args[1].toJava(Vec2.class);
+            u = texture.javax();
+            v = texture.javay();
+        }
+        JRender renderer = (JRender) args[0].toJava(JRender.class);
+        renderer.vertex(jx, jy, jz, u, v);
+    }
+
+    /**
+     * Sends this Vec3D as a processing normal
+     *
+     * @param context ThreadContext
+     * @param object IRubyObject vertex renderer
+     */
+    @JRubyMethod(name = "to_normal")
+    public void toNormal(ThreadContext context, IRubyObject object) {
+        JRender renderer = (JRender) object.toJava(JRender.class);
+        renderer.normal(jx, jy, jz);
+    }
+
+    /**
+     * For jruby-9000 we alias to inspect
+     *
+     * @param context ThreadContext
+     * @return IRubyObject to_s
+     */
+    @JRubyMethod(name = {"to_s", "inspect"})
+    public IRubyObject to_s(ThreadContext context) {
+        return context.runtime.newString(String.format("Vec3D(x = %4.4f, y = %4.4f, z = %4.4f)", jx, jy, jz));
+    }
+
+    /**
+     * Java hash
+     *
+     * @return hash int
+     */
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 97 * hash + (int) (Double.doubleToLongBits(this.jx) ^ (Double.doubleToLongBits(this.jx) >>> 32));
+        hash = 97 * hash + (int) (Double.doubleToLongBits(this.jy) ^ (Double.doubleToLongBits(this.jy) >>> 32));
+        hash = 97 * hash + (int) (Double.doubleToLongBits(this.jz) ^ (Double.doubleToLongBits(this.jz) >>> 32));
+        return hash;
+    }
+
+    /**
+     * Java Equals
+     *
+     * @param obj Object
+     * @return result boolean
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj instanceof Vec3) {
+            final Vec3 other = (Vec3) obj;
+            if ((Double.compare(jx, (Double) other.jx) == 0)
+                    && (Double.compare(jy, (Double) other.jy) == 0)
+                    && (Double.compare(jz, (Double) other.jz) == 0)) {
+                return true;
+            }
+
+        }
+        return false;
+    }
+
+    /**
+     *
+     * @param context ThreadContext
+     * @param other IRubyObject
+     * @return result IRubyObject as boolean
+     */
+    @JRubyMethod(name = "eql?", required = 1)
+    public IRubyObject eql_p(ThreadContext context, IRubyObject other) {
+        Ruby runtime = context.runtime;
+        if (other == this) {
+            return runtime.newBoolean(true);
+        }
+        if (other instanceof Vec3) {
+            Vec3 v = (Vec3) other.toJava(Vec3.class);
+            if ((Double.compare(jx, (Double) v.jx) == 0)
+                    && (Double.compare(jy, (Double) v.jy) == 0)
+                    && (Double.compare(jz, (Double) v.jz) == 0)) {
+                return runtime.newBoolean(true);
+            }
+
+        }
+        return runtime.newBoolean(false);
+    }
+
+    /**
+     *
+     * @param context ThreadContext
+     * @param other IRubyObject
+     * @return result IRubyObject as boolean
+     */
+    @JRubyMethod(name = "==", required = 1)
+    @Override
+    public IRubyObject op_equal(ThreadContext context, IRubyObject other) {
+        Ruby runtime = context.runtime;
+        if (other == this) {
+            return runtime.newBoolean(true);
+        }
+        if (other instanceof Vec3) {
+            Vec3 v = (Vec3) other.toJava(Vec3.class);
+            double diff = jx - v.jx;
+            if ((diff < 0 ? -diff : diff) > Vec3.EPSILON) {
+                return runtime.newBoolean(false);
+            }
+            diff = jy - v.jy;
+            if ((diff < 0 ? -diff : diff) > Vec3.EPSILON) {
+                return runtime.newBoolean(false);
+            }
+            diff = jz - v.jz;
+            return runtime.newBoolean((diff < 0 ? -diff : diff) < Vec3.EPSILON);
+        }
+        return runtime.newBoolean(false);
+    }
+}

--- a/src/monkstone/vecmath/vec3/Vec3.java
+++ b/src/monkstone/vecmath/vec3/Vec3.java
@@ -92,6 +92,14 @@ public final class Vec3 extends RubyObject {
         if (count == 3) {
             jz = (args[2] instanceof RubyFloat)
                     ? ((RubyFloat) args[2]).getValue() : ((RubyFixnum) args[2]).getDoubleValue();
+        } // allow ruby ducktyping in constructor
+        if (count == 1) {
+            jx = ((args[0].callMethod(context, "x")) instanceof RubyFloat)
+                    ? ((RubyFloat) args[0].callMethod(context, "x")).getValue() : ((RubyFixnum) args[0].callMethod(context, "x")).getDoubleValue();
+            jy = ((args[0].callMethod(context, "y")) instanceof RubyFloat)
+                    ? ((RubyFloat) args[0].callMethod(context, "y")).getValue() : ((RubyFixnum) args[0].callMethod(context, "y")).getDoubleValue();
+            jz = ((args[0].callMethod(context, "z")) instanceof RubyFloat)
+                    ? ((RubyFloat) args[0].callMethod(context, "z")).getValue() : ((RubyFixnum) args[0].callMethod(context, "z")).getDoubleValue();
         }
     }
 

--- a/src/monkstone/vecmath/vec3/Vec3.java
+++ b/src/monkstone/vecmath/vec3/Vec3.java
@@ -94,7 +94,7 @@ public final class Vec3 extends RubyObject {
                     ? ((RubyFloat) args[2]).getValue() : ((RubyFixnum) args[2]).getDoubleValue();
         } // allow ruby ducktyping in constructor
         if (count == 1) {
-            if (!(args[0].respondsTo("x"))) {throw context.runtime.newTypeError("argument should respond_to :x, :y");}
+            if (!(args[0].respondsTo("x"))) {throw context.runtime.newTypeError(args[0].getType() + " doesn't respond_to :x & :y");}
             jx = ((args[0].callMethod(context, "x")) instanceof RubyFloat)
                     ? ((RubyFloat) args[0].callMethod(context, "x")).getValue() : ((RubyFixnum) args[0].callMethod(context, "x")).getDoubleValue();
             jy = ((args[0].callMethod(context, "y")) instanceof RubyFloat)
@@ -113,7 +113,7 @@ public final class Vec3 extends RubyObject {
 
         public IRubyObject getX
         (ThreadContext context
-        
+
             ) {
         return context.runtime.newFloat(jx);
         }
@@ -127,7 +127,7 @@ public final class Vec3 extends RubyObject {
 
         public IRubyObject getY
         (ThreadContext context
-        
+
             ) {
         return context.runtime.newFloat(jy);
         }
@@ -140,7 +140,7 @@ public final class Vec3 extends RubyObject {
         @JRubyMethod(name = "z")
         public IRubyObject getZ
         (ThreadContext context
-        
+
             ) {
         return context.runtime.newFloat(jz);
         }
@@ -155,7 +155,7 @@ public final class Vec3 extends RubyObject {
 
         public IRubyObject setX
         (ThreadContext context, IRubyObject other
-        
+
             ) {
         if (other instanceof RubyFloat) {
                 jx = ((RubyFloat) other).getValue();
@@ -175,7 +175,7 @@ public final class Vec3 extends RubyObject {
 
         public IRubyObject setY
         (ThreadContext context, IRubyObject other
-        
+
             ) {
         if (other instanceof RubyFloat) {
                 jy = ((RubyFloat) other).getValue();
@@ -194,7 +194,7 @@ public final class Vec3 extends RubyObject {
         @JRubyMethod(name = "z=")
         public IRubyObject setZ
         (ThreadContext context, IRubyObject other
-        
+
             ) {
         if (other instanceof RubyFloat) {
                 jz = ((RubyFloat) other).getValue();
@@ -214,7 +214,7 @@ public final class Vec3 extends RubyObject {
 
         public IRubyObject aref
         (ThreadContext context, IRubyObject key
-        
+
             ) {
         Ruby runtime = context.runtime;
             if (key instanceof RubySymbol) {
@@ -243,7 +243,7 @@ public final class Vec3 extends RubyObject {
         public IRubyObject aset
         (ThreadContext context, IRubyObject key
         , IRubyObject value
-        
+
             ) {
         Ruby runtime = context.runtime;
             if (key instanceof RubySymbol) {
@@ -275,7 +275,7 @@ public final class Vec3 extends RubyObject {
 
         public IRubyObject dist
         (ThreadContext context, IRubyObject other
-        
+
             ) {
         Vec3 b = null;
             if (other instanceof Vec3) {
@@ -297,7 +297,7 @@ public final class Vec3 extends RubyObject {
 
         public IRubyObject dist_squared
         (ThreadContext context, IRubyObject other
-        
+
             ) {
         Vec3 b = null;
             if (other instanceof Vec3) {
@@ -320,7 +320,7 @@ public final class Vec3 extends RubyObject {
 
         public IRubyObject cross
         (ThreadContext context, IRubyObject other
-        
+
             ) {
         Ruby runtime = context.runtime;
             Vec3 vec = null;
@@ -347,7 +347,7 @@ public final class Vec3 extends RubyObject {
 
         public IRubyObject dot
         (ThreadContext context, IRubyObject other
-        
+
             ) {
         Ruby runtime = context.runtime;
             Vec3 b = null;
@@ -369,7 +369,7 @@ public final class Vec3 extends RubyObject {
 
         public IRubyObject op_add
         (ThreadContext context, IRubyObject other
-        
+
             ) {
         Ruby runtime = context.runtime;
             Vec3 b = (Vec3) other.toJava(Vec3.class);
@@ -389,7 +389,7 @@ public final class Vec3 extends RubyObject {
 
         public IRubyObject op_sub
         (ThreadContext context, IRubyObject other
-        
+
             ) {
         Ruby runtime = context.runtime;
             Vec3 b = null;
@@ -414,7 +414,7 @@ public final class Vec3 extends RubyObject {
 
         public IRubyObject op_mul
         (ThreadContext context, IRubyObject scalar
-        
+
             ) {
         Ruby runtime = context.runtime;
             double multi = (scalar instanceof RubyFloat)
@@ -435,7 +435,7 @@ public final class Vec3 extends RubyObject {
 
         public IRubyObject op_div
         (ThreadContext context, IRubyObject scalar
-        
+
             ) {
         Ruby runtime = context.runtime;
             double divisor = (scalar instanceof RubyFloat)
@@ -458,7 +458,7 @@ public final class Vec3 extends RubyObject {
 
         public IRubyObject mag_squared
         (ThreadContext context
-        
+
             ) {
         return context.runtime.newFloat(jx * jx + jy * jy + jz * jz);
         }
@@ -472,7 +472,7 @@ public final class Vec3 extends RubyObject {
 
         public IRubyObject mag
         (ThreadContext context
-        
+
             ) {
         return context.runtime.newFloat(Math.sqrt(jx * jx + jy * jy + jz * jz));
         }
@@ -491,7 +491,7 @@ public final class Vec3 extends RubyObject {
         public IRubyObject set_mag
         (ThreadContext context, IRubyObject scalar
         , Block block
-        
+
             ) {
         if (block.isGiven()) {
                 if (!(boolean) block.yield(context, scalar).toJava(Boolean.class)) {
@@ -518,7 +518,7 @@ public final class Vec3 extends RubyObject {
 
         public IRubyObject normalize_bang
         (ThreadContext context
-        
+
             ) {
         if (Math.abs(jx) < EPSILON && Math.abs(jy) < EPSILON && Math.abs(jz) < EPSILON) {
                 return this;
@@ -539,7 +539,7 @@ public final class Vec3 extends RubyObject {
 
         public IRubyObject normalize
         (ThreadContext context
-        
+
             ) {
         Ruby runtime = context.runtime;
             double mag = Math.sqrt(jx * jx + jy * jy + jz * jz);
@@ -566,7 +566,7 @@ public final class Vec3 extends RubyObject {
 
         public static IRubyObject random_direction
         (ThreadContext context, IRubyObject klazz
-        
+
             ) {
         Ruby runtime = context.runtime;
             double angle = Math.random() * Math.PI * 2;
@@ -590,7 +590,7 @@ public final class Vec3 extends RubyObject {
 
         public IRubyObject angleBetween
         (ThreadContext context, IRubyObject other
-        
+
             ) {
         Ruby runtime = context.runtime;
             Vec3 vec = (Vec3) other.toJava(Vec3.class);
@@ -625,7 +625,7 @@ public final class Vec3 extends RubyObject {
 
         public IRubyObject copy
         (ThreadContext context
-        
+
             ) {
         Ruby runtime = context.runtime;
             return Vec3.rbNew(context, this.getMetaClass(), new IRubyObject[]{
@@ -643,7 +643,7 @@ public final class Vec3 extends RubyObject {
 
         public IRubyObject toArray
         (ThreadContext context
-        
+
             ) {
         Ruby runtime = context.runtime;
             return RubyArray.newArray(context.runtime, new IRubyObject[]{
@@ -662,7 +662,7 @@ public final class Vec3 extends RubyObject {
 
         public void toVertex
         (ThreadContext context, IRubyObject object
-        
+
             ) {
         JRender renderer = (JRender) object.toJava(JRender.class);
             renderer.vertex(jx, jy, jz);
@@ -678,7 +678,7 @@ public final class Vec3 extends RubyObject {
 
         public void toCurveVertex
         (ThreadContext context, IRubyObject object
-        
+
             ) {
         JRender renderer = (JRender) object.toJava(JRender.class);
             renderer.curveVertex(jx, jy, jz);
@@ -694,7 +694,7 @@ public final class Vec3 extends RubyObject {
 
         public void toVertexUV
         (ThreadContext context, IRubyObject[] args
-        
+
             ) {
         int count = Arity.checkArgumentCount(context.runtime, args, Arity.OPTIONAL.getValue(), 3);
             double u = 0;
@@ -724,7 +724,7 @@ public final class Vec3 extends RubyObject {
 
         public void toNormal
         (ThreadContext context, IRubyObject object
-        
+
             ) {
         JRender renderer = (JRender) object.toJava(JRender.class);
             renderer.normal(jx, jy, jz);
@@ -740,7 +740,7 @@ public final class Vec3 extends RubyObject {
 
         public IRubyObject to_s
         (ThreadContext context
-        
+
             ) {
         return context.runtime.newString(String.format("Vec3D(x = %4.4f, y = %4.4f, z = %4.4f)", jx, jy, jz));
         }
@@ -752,7 +752,7 @@ public final class Vec3 extends RubyObject {
          */
         @Override
         public int hashCode
-        
+
             () {
         int hash = 7;
             hash = 97 * hash + (int) (Double.doubleToLongBits(this.jx) ^ (Double.doubleToLongBits(this.jx) >>> 32));
@@ -770,7 +770,7 @@ public final class Vec3 extends RubyObject {
         @Override
         public boolean equals
         (Object obj
-        
+
             ) {
         if (obj == this) {
                 return true;
@@ -797,7 +797,7 @@ public final class Vec3 extends RubyObject {
 
         public IRubyObject eql_p
         (ThreadContext context, IRubyObject other
-        
+
             ) {
         Ruby runtime = context.runtime;
             if (other == this) {
@@ -826,7 +826,7 @@ public final class Vec3 extends RubyObject {
         @Override
         public IRubyObject op_equal
         (ThreadContext context, IRubyObject other
-        
+
             ) {
         Ruby runtime = context.runtime;
             if (other == this) {

--- a/test/vecmath_spec_test.rb
+++ b/test/vecmath_spec_test.rb
@@ -222,7 +222,7 @@ class VecmathTest < Minitest::Test
     x, y = 20, 10
     b = Vec2D.new(x, y)
     a = b.rotate(Math::PI / 2)
-    assert_equal(a, Vec2D.new(-10, 20), 'Failed to rotate Point by scalar radians')
+    assert_equal(a, Vec2D.new(-10, 20), 'Failed to rotate vector by scalar radians')
   end
 
   def test_hash_index

--- a/test/vecmath_spec_test.rb
+++ b/test/vecmath_spec_test.rb
@@ -77,14 +77,14 @@ class VecmathTest < Minitest::Test
     a = Vec2D.new(3, 5)
     b = Vec2D.new(6, 7)
     c = Vec2D.new(9, 12)
-    assert_equal(a + b, c, 'Failed to sum Points')
+    assert_equal(a + b, c, 'Failed to sum vectors')
   end
 
   def test_subtract
     a = Vec2D.new(3, 5)
     b = Vec2D.new(6, 7)
     c = Vec2D.new(-3, -2)
-    assert_equal(a - b, c, 'Failed to subtract Points')
+    assert_equal(a - b, c, 'Failed to subtract vectors')
   end
 
   def test_multiply
@@ -92,7 +92,7 @@ class VecmathTest < Minitest::Test
     b = 2
     c = a * b
     d = Vec2D.new(6, 10)
-    assert_equal(c, d, 'Failed to multiply Point by scalar')
+    assert_equal(c, d, 'Failed to multiply vector by scalar')
   end
 
   def test_divide
@@ -100,7 +100,7 @@ class VecmathTest < Minitest::Test
     b = 2
     c = Vec2D.new(1.5, 2.5)
     d = a / b
-    assert_equal(c, d, 'Failed to divide Point by scalar')
+    assert_equal(c, d, 'Failed to divide vector by scalar')
   end
 
   def test_dot
@@ -116,7 +116,7 @@ class VecmathTest < Minitest::Test
 
   def test_from_angle
     a = Vec2D.from_angle(Math::PI * 0.75)
-    assert_equal(a, Vec2D.new(-1 * Math.sqrt(0.5), Math.sqrt(0.5)), 'Failed to create Point from angle')
+    assert_equal(a, Vec2D.new(-1 * Math.sqrt(0.5), Math.sqrt(0.5)), 'Failed to create vector from angle')
   end
 
   def test_random
@@ -133,65 +133,65 @@ class VecmathTest < Minitest::Test
 
   def test_mag
     a = Vec2D.new(-3, -4)
-    assert_in_epsilon(a.mag, 5, 0.001,'Failed to return magnitude of Point')
+    assert_in_epsilon(a.mag, 5, 0.001,'Failed to return magnitude of vector')
   end
 
   def test_mag_variant
     a = Vec2D.new(3.0, 2)
     b = Math.sqrt(3.0**2 + 2**2)
-    assert_in_epsilon(a.mag, b, 0.001, 'Failed to return magnitude of Point')
+    assert_in_epsilon(a.mag, b, 0.001, 'Failed to return magnitude of vector')
   end
 
   def test_mag_zero_one
     a = Vec2D.new(-1, 0)
-    assert_in_epsilon(a.mag, 1, 0.001, 'Failed to return magnitude of Point')
+    assert_in_epsilon(a.mag, 1, 0.001, 'Failed to return magnitude of vector')
   end
 
   def test_dist
     a = Vec2D.new(3, 5)
     b = Vec2D.new(6, 7)
-    assert_in_epsilon(a.dist(b), Math.sqrt(3.0**2 + 2**2), 'Failed to return distance between two Points')
+    assert_in_epsilon(a.dist(b), Math.sqrt(3.0**2 + 2**2), 'Failed to return distance between two vectors')
   end
 
   def test_lerp
     a = Vec2D.new(1, 1)
     b = Vec2D.new(3, 3)
-    assert_equal(a.lerp(b, 0.5), Vec2D.new(2, 2), 'Failed to return lerp between two Points')
+    assert_equal(a.lerp(b, 0.5), Vec2D.new(2, 2), 'Failed to return lerp between two vectors')
   end
 
   def test_lerp_unclamped
     a = Vec2D.new(1, 1)
     b = Vec2D.new(3, 3)
-    assert_equal(a.lerp(b, 5), Vec2D.new(11, 11), 'Failed to return lerp between two Points')
+    assert_equal(a.lerp(b, 5), Vec2D.new(11, 11), 'Failed to return lerp between two vectors')
   end
 
     def test_lerp!
     a = Vec2D.new(1, 1)
     b = Vec2D.new(3, 3)
     a.lerp!(b, 0.5)
-    assert_equal(a, Vec2D.new(2, 2), 'Failed to return lerp! between two Points')
+    assert_equal(a, Vec2D.new(2, 2), 'Failed to return lerp! between two vectors')
   end
 
   def test_lerp_unclamped!
     a = Vec2D.new(1, 1)
     b = Vec2D.new(3, 3)
     a.lerp!(b, 5)
-    assert_equal(a, Vec2D.new(11, 11), 'Failed to return lerp! between two Points')
+    assert_equal(a, Vec2D.new(11, 11), 'Failed to return lerp! between two vectors')
   end
 
   def test_set_mag
     a = Vec2D.new(1, 1)
-    assert_equal(a.set_mag(Math.sqrt(32)), Vec2D.new(4, 4), 'Failed to set_mag Point')
+    assert_equal(a.set_mag(Math.sqrt(32)), Vec2D.new(4, 4), 'Failed to set_mag vector')
   end
 
   def test_set_mag_block
     a = Vec2D.new(1, 1)
-    assert_equal(a.set_mag(Math.sqrt(32)) { true }, Vec2D.new(4, 4), 'Failed to set_mag_block true Point')
+    assert_equal(a.set_mag(Math.sqrt(32)) { true }, Vec2D.new(4, 4), 'Failed to set_mag_block true vector')
   end
 
   def test_set_mag_block_false
     a = Vec2D.new(1, 1)
-    assert_equal(a.set_mag(Math.sqrt(32)) { false }, Vec2D.new(1, 1), 'Failed to set_mag_block true Point')
+    assert_equal(a.set_mag(Math.sqrt(32)) { false }, Vec2D.new(1, 1), 'Failed to set_mag_block true vector')
   end
 
   def test_plus_assign
@@ -204,13 +204,13 @@ class VecmathTest < Minitest::Test
   def test_normalize
     a = Vec2D.new(3, 5)
     b = a.normalize
-    assert_in_epsilon(b.mag, 1, 0.001, 'Failed to return a normalized Point')
+    assert_in_epsilon(b.mag, 1, 0.001, 'Failed to return a normalized vector')
   end
 
   def test_normalize!
     a = Vec2D.new(3, 5)
     a.normalize!
-    assert_in_epsilon(a.mag, 1, 0.001, 'Failed to return a normalized! Point')
+    assert_in_epsilon(a.mag, 1, 0.001, 'Failed to return a normalized! vector')
   end
 
   def test_heading
@@ -260,15 +260,15 @@ class VecmathTest < Minitest::Test
   def test_cross_area # NB: the sign might be negative
     a = Vec2D.new(200, 0)
     b = Vec2D.new(0, 200)
-    # Expected result is an area, twice that of the triangle created by the Points
-    assert_equal((a).cross(b).abs, 40_000.0, 'Failed area test using 2D Point cross product')
+    # Expected result is an area, twice that of the triangle created by the vectors
+    assert_equal((a).cross(b).abs, 40_000.0, 'Failed area test using 2D vector cross product')
   end
 
   def test_cross_non_zero # Could be used to calculate area of triangle
     a = Vec2D.new(40, 40)
     b = Vec2D.new(40, 140)
     c = Vec2D.new(140, 40)
-    assert_equal((a - b).cross(b - c).abs / 2, 5_000.0, 'Failed area calculation using 2D Point cross product')
+    assert_equal((a - b).cross(b - c).abs / 2, 5_000.0, 'Failed area calculation using 2D vector cross product')
   end
 
   def test_cross_zero # where a, b, c are collinear area == 0
@@ -276,7 +276,7 @@ class VecmathTest < Minitest::Test
     b = Vec2D.new(100, 100)
     c = Vec2D.new(200, 200)
     # see http://mathworld.wolfram.com/Collinear.html for details
-    assert((a - b).cross(b - c).zero?, 'Failed collinearity test using 2D Point cross product')
+    assert((a - b).cross(b - c).zero?, 'Failed collinearity test using 2D vector cross product')
   end
 
   def test_equals
@@ -335,14 +335,14 @@ class VecmathTest < Minitest::Test
     a = Vec3D.new(3, 5, 1)
     b = Vec3D.new(6, 7, 1)
     c = Vec3D.new(9, 12, 2)
-    assert_equal(a + b, c, 'Failed to sum Points')
+    assert_equal(a + b, c, 'Failed to sum vectors')
   end
 
   def test_subtract
     a = Vec3D.new(3, 5, 0)
     b = Vec3D.new(6, 7, 1)
     c = Vec3D.new(-3, -2, -1)
-    assert_equal(a - b, c, 'Failed to subtract Points')
+    assert_equal(a - b, c, 'Failed to subtract vectors')
   end
 
   def test_multiply
@@ -350,7 +350,7 @@ class VecmathTest < Minitest::Test
     b = 2
     c = a * b
     d = Vec3D.new(6, 10, 2)
-    assert_equal(c, d, 'Failed to multiply Point by scalar')
+    assert_equal(c, d, 'Failed to multiply vector by scalar')
   end
 
   def test_divide
@@ -358,7 +358,7 @@ class VecmathTest < Minitest::Test
     b = 2
     c = Vec3D.new(1.5, 2.5, 2)
     d = a / b
-    assert_equal(c, d, 'Failed to divide Point by scalar')
+    assert_equal(c, d, 'Failed to divide vector by scalar')
   end
 
   def test_random
@@ -375,31 +375,31 @@ class VecmathTest < Minitest::Test
 
   def test_mag
     a = Vec3D.new(-3, -4)
-    assert_equal(a.mag, 5, 'Failed to return magnitude of Point')
+    assert_equal(a.mag, 5, 'Failed to return magnitude of vector')
   end
 
   def test_mag_variant
     a = Vec3D.new(3.0, 2)
     b = Math.sqrt(3.0**2 + 2**2)
-    assert_in_epsilon(a.mag, b, 0.001, 'Failed to return magnitude of Point')
+    assert_in_epsilon(a.mag, b, 0.001, 'Failed to return magnitude of vector')
   end
 
   def test_mag_zero_one
     a = Vec3D.new(-1, 0)
-    assert_equal(a.mag, 1, 'Failed to return magnitude of Point')
+    assert_equal(a.mag, 1, 'Failed to return magnitude of vector')
   end
 
   def test_dist
     a = Vec3D.new(3, 5, 2)
     b = Vec3D.new(6, 7, 1)
-    message = 'Failed to return distance between two Points'
+    message = 'Failed to return distance between two vectors'
     assert_equal(a.dist(b), Math.sqrt(3.0**2 + 2**2 + 1), message)
   end
 
   def test_dist_squared
     a = Vec3D.new(3, 5, 2)
     b = Vec3D.new(6, 7, 1)
-    message = 'Failed to return distance squared between two Points'
+    message = 'Failed to return distance squared between two vectors'
     assert_equal(a.dist_squared(b), 3.0**2 + 2**2 + 1, message)
   end
 
@@ -423,17 +423,17 @@ class VecmathTest < Minitest::Test
 
   def test_set_mag
     a = Vec3D.new(1, 1)
-    assert_equal(a.set_mag(Math.sqrt(32)), Vec3D.new(4, 4), 'Failed to set_mag Point')
+    assert_equal(a.set_mag(Math.sqrt(32)), Vec3D.new(4, 4), 'Failed to set_mag vector')
   end
 
   def test_set_mag_block
     a = Vec3D.new(1, 1)
-    assert_equal(a.set_mag(Math.sqrt(32)) { true }, Vec3D.new(4, 4), 'Failed to set_mag_block true Point')
+    assert_equal(a.set_mag(Math.sqrt(32)) { true }, Vec3D.new(4, 4), 'Failed to set_mag_block true vector')
   end
 
   def test_set_mag_block_false
     a = Vec3D.new(1, 1)
-    assert_equal(a.set_mag(Math.sqrt(32)) { false }, Vec3D.new(1, 1), 'Failed to set_mag_block true Point')
+    assert_equal(a.set_mag(Math.sqrt(32)) { false }, Vec3D.new(1, 1), 'Failed to set_mag_block true vector')
   end
 
   def test_plus_assign
@@ -446,13 +446,13 @@ class VecmathTest < Minitest::Test
   def test_normalize
     a = Vec3D.new(3, 5)
     b = a.normalize
-    assert_in_epsilon(b.mag, 1, 0.001, 'Failed to return a normalized Point')
+    assert_in_epsilon(b.mag, 1, 0.001, 'Failed to return a normalized vector')
   end
 
   def test_normalize!
     a = Vec3D.new(3, 5)
     a.normalize!
-    assert_in_epsilon(a.mag, 1, 0.001, 'Failed to return a normalized! Point')
+    assert_in_epsilon(a.mag, 1, 0.001, 'Failed to return a normalized! vector')
   end
 
   def test_inspect

--- a/test/vecmath_spec_test.rb
+++ b/test/vecmath_spec_test.rb
@@ -10,10 +10,13 @@ Dir.chdir(File.dirname(__FILE__))
 class VecmathTest < Minitest::Test
 
   # duck for Vec2D constructor
-  Vector = Struct.new(:x, :y)
-    # duck for Vec3D constructor
-  Vector3 = Struct.new(:x, :y, :z)
-
+  Point = Struct.new(:x, :y)
+  # duck for Vec3D constructor
+  Point3 = Struct.new(:x, :y, :z)
+  # non-duck to test fail
+  Pointless = Struct.new(:a, :b)
+  # non-duck to test fail
+  Pointless3 = Struct.new(:a, :b, :c)
   def setup
 
   end
@@ -38,15 +41,22 @@ class VecmathTest < Minitest::Test
   end
 
   def test_constructor_float
-    val = Vector.new(1.0, 8.0) # duck type
+    val = Point.new(1.0, 8.0) # duck type
     expected = Vec2D.new(val)
     assert_equal(expected, Vec2D.new(1.0, 8.0), 'Failed duck type constructor floats')
   end
 
   def test_constructor_fixnum
-    val = Vector.new(1, 8) # duck type fixnum
+    val = Point.new(1, 8) # duck type fixnum
     expected = Vec2D.new(val)
     assert_equal(expected, Vec2D.new(1.0, 8.0), 'Failed duck type constructor fixnum')
+  end
+
+  def test_failed_duck_type
+    val = Pointless.new(1.0, 8.0) # non duck type
+    assert_raises TypeError do
+      Vec2D.new(val)
+    end
   end
 
   def test_copy_not_equals
@@ -67,14 +77,14 @@ class VecmathTest < Minitest::Test
     a = Vec2D.new(3, 5)
     b = Vec2D.new(6, 7)
     c = Vec2D.new(9, 12)
-    assert_equal(a + b, c, 'Failed to sum vectors')
+    assert_equal(a + b, c, 'Failed to sum Points')
   end
 
   def test_subtract
     a = Vec2D.new(3, 5)
     b = Vec2D.new(6, 7)
     c = Vec2D.new(-3, -2)
-    assert_equal(a - b, c, 'Failed to subtract vectors')
+    assert_equal(a - b, c, 'Failed to subtract Points')
   end
 
   def test_multiply
@@ -82,7 +92,7 @@ class VecmathTest < Minitest::Test
     b = 2
     c = a * b
     d = Vec2D.new(6, 10)
-    assert_equal(c, d, 'Failed to multiply vector by scalar')
+    assert_equal(c, d, 'Failed to multiply Point by scalar')
   end
 
   def test_divide
@@ -90,7 +100,7 @@ class VecmathTest < Minitest::Test
     b = 2
     c = Vec2D.new(1.5, 2.5)
     d = a / b
-    assert_equal(c, d, 'Failed to divide vector by scalar')
+    assert_equal(c, d, 'Failed to divide Point by scalar')
   end
 
   def test_dot
@@ -106,7 +116,7 @@ class VecmathTest < Minitest::Test
 
   def test_from_angle
     a = Vec2D.from_angle(Math::PI * 0.75)
-    assert_equal(a, Vec2D.new(-1 * Math.sqrt(0.5), Math.sqrt(0.5)), 'Failed to create vector from angle')
+    assert_equal(a, Vec2D.new(-1 * Math.sqrt(0.5), Math.sqrt(0.5)), 'Failed to create Point from angle')
   end
 
   def test_random
@@ -123,65 +133,65 @@ class VecmathTest < Minitest::Test
 
   def test_mag
     a = Vec2D.new(-3, -4)
-    assert_in_epsilon(a.mag, 5, 0.001,'Failed to return magnitude of vector')
+    assert_in_epsilon(a.mag, 5, 0.001,'Failed to return magnitude of Point')
   end
 
   def test_mag_variant
     a = Vec2D.new(3.0, 2)
     b = Math.sqrt(3.0**2 + 2**2)
-    assert_in_epsilon(a.mag, b, 0.001, 'Failed to return magnitude of vector')
+    assert_in_epsilon(a.mag, b, 0.001, 'Failed to return magnitude of Point')
   end
 
   def test_mag_zero_one
     a = Vec2D.new(-1, 0)
-    assert_in_epsilon(a.mag, 1, 0.001, 'Failed to return magnitude of vector')
+    assert_in_epsilon(a.mag, 1, 0.001, 'Failed to return magnitude of Point')
   end
 
   def test_dist
     a = Vec2D.new(3, 5)
     b = Vec2D.new(6, 7)
-    assert_in_epsilon(a.dist(b), Math.sqrt(3.0**2 + 2**2), 'Failed to return distance between two vectors')
+    assert_in_epsilon(a.dist(b), Math.sqrt(3.0**2 + 2**2), 'Failed to return distance between two Points')
   end
 
   def test_lerp
     a = Vec2D.new(1, 1)
     b = Vec2D.new(3, 3)
-    assert_equal(a.lerp(b, 0.5), Vec2D.new(2, 2), 'Failed to return lerp between two vectors')
+    assert_equal(a.lerp(b, 0.5), Vec2D.new(2, 2), 'Failed to return lerp between two Points')
   end
 
   def test_lerp_unclamped
     a = Vec2D.new(1, 1)
     b = Vec2D.new(3, 3)
-    assert_equal(a.lerp(b, 5), Vec2D.new(11, 11), 'Failed to return lerp between two vectors')
+    assert_equal(a.lerp(b, 5), Vec2D.new(11, 11), 'Failed to return lerp between two Points')
   end
 
     def test_lerp!
     a = Vec2D.new(1, 1)
     b = Vec2D.new(3, 3)
     a.lerp!(b, 0.5)
-    assert_equal(a, Vec2D.new(2, 2), 'Failed to return lerp! between two vectors')
+    assert_equal(a, Vec2D.new(2, 2), 'Failed to return lerp! between two Points')
   end
 
   def test_lerp_unclamped!
     a = Vec2D.new(1, 1)
     b = Vec2D.new(3, 3)
     a.lerp!(b, 5)
-    assert_equal(a, Vec2D.new(11, 11), 'Failed to return lerp! between two vectors')
+    assert_equal(a, Vec2D.new(11, 11), 'Failed to return lerp! between two Points')
   end
 
   def test_set_mag
     a = Vec2D.new(1, 1)
-    assert_equal(a.set_mag(Math.sqrt(32)), Vec2D.new(4, 4), 'Failed to set_mag vector')
+    assert_equal(a.set_mag(Math.sqrt(32)), Vec2D.new(4, 4), 'Failed to set_mag Point')
   end
 
   def test_set_mag_block
     a = Vec2D.new(1, 1)
-    assert_equal(a.set_mag(Math.sqrt(32)) { true }, Vec2D.new(4, 4), 'Failed to set_mag_block true vector')
+    assert_equal(a.set_mag(Math.sqrt(32)) { true }, Vec2D.new(4, 4), 'Failed to set_mag_block true Point')
   end
 
   def test_set_mag_block_false
     a = Vec2D.new(1, 1)
-    assert_equal(a.set_mag(Math.sqrt(32)) { false }, Vec2D.new(1, 1), 'Failed to set_mag_block true vector')
+    assert_equal(a.set_mag(Math.sqrt(32)) { false }, Vec2D.new(1, 1), 'Failed to set_mag_block true Point')
   end
 
   def test_plus_assign
@@ -194,13 +204,13 @@ class VecmathTest < Minitest::Test
   def test_normalize
     a = Vec2D.new(3, 5)
     b = a.normalize
-    assert_in_epsilon(b.mag, 1, 0.001, 'Failed to return a normalized vector')
+    assert_in_epsilon(b.mag, 1, 0.001, 'Failed to return a normalized Point')
   end
 
   def test_normalize!
     a = Vec2D.new(3, 5)
     a.normalize!
-    assert_in_epsilon(a.mag, 1, 0.001, 'Failed to return a normalized! vector')
+    assert_in_epsilon(a.mag, 1, 0.001, 'Failed to return a normalized! Point')
   end
 
   def test_heading
@@ -212,7 +222,7 @@ class VecmathTest < Minitest::Test
     x, y = 20, 10
     b = Vec2D.new(x, y)
     a = b.rotate(Math::PI / 2)
-    assert_equal(a, Vec2D.new(-10, 20), 'Failed to rotate vector by scalar radians')
+    assert_equal(a, Vec2D.new(-10, 20), 'Failed to rotate Point by scalar radians')
   end
 
   def test_hash_index
@@ -250,15 +260,15 @@ class VecmathTest < Minitest::Test
   def test_cross_area # NB: the sign might be negative
     a = Vec2D.new(200, 0)
     b = Vec2D.new(0, 200)
-    # Expected result is an area, twice that of the triangle created by the vectors
-    assert_equal((a).cross(b).abs, 40_000.0, 'Failed area test using 2D vector cross product')
+    # Expected result is an area, twice that of the triangle created by the Points
+    assert_equal((a).cross(b).abs, 40_000.0, 'Failed area test using 2D Point cross product')
   end
 
   def test_cross_non_zero # Could be used to calculate area of triangle
     a = Vec2D.new(40, 40)
     b = Vec2D.new(40, 140)
     c = Vec2D.new(140, 40)
-    assert_equal((a - b).cross(b - c).abs / 2, 5_000.0, 'Failed area calculation using 2D vector cross product')
+    assert_equal((a - b).cross(b - c).abs / 2, 5_000.0, 'Failed area calculation using 2D Point cross product')
   end
 
   def test_cross_zero # where a, b, c are collinear area == 0
@@ -266,7 +276,7 @@ class VecmathTest < Minitest::Test
     b = Vec2D.new(100, 100)
     c = Vec2D.new(200, 200)
     # see http://mathworld.wolfram.com/Collinear.html for details
-    assert((a - b).cross(b - c).zero?, 'Failed collinearity test using 2D vector cross product')
+    assert((a - b).cross(b - c).zero?, 'Failed collinearity test using 2D Point cross product')
   end
 
   def test_equals
@@ -276,15 +286,22 @@ class VecmathTest < Minitest::Test
   end
 
   def test_constructor_float
-    val = Vector3.new(1.0, 8.0, 7.0) # duck type
+    val = Point3.new(1.0, 8.0, 7.0) # duck type
     expected = Vec3D.new(val)
     assert_equal(expected, Vec3D.new(1.0, 8.0, 7.0), 'Failed duck type constructor floats')
   end
 
   def test_constructor_fixnum
-    val = Vector3.new(1, 8, 7) # duck type fixnum
+    val = Point3.new(1, 8, 7) # duck type fixnum
     expected = Vec3D.new(val)
     assert_equal(expected, Vec3D.new(1.0, 8.0, 7.0), 'Failed duck type constructor fixnum')
+  end
+
+  def test_failed_duck_type
+    val = Pointless3.new(1.0, 8.0, 7.0) # non duck type
+    assert_raises TypeError do
+      Vec3D.new(val)
+    end
   end
 
   def test_not_equals
@@ -318,14 +335,14 @@ class VecmathTest < Minitest::Test
     a = Vec3D.new(3, 5, 1)
     b = Vec3D.new(6, 7, 1)
     c = Vec3D.new(9, 12, 2)
-    assert_equal(a + b, c, 'Failed to sum vectors')
+    assert_equal(a + b, c, 'Failed to sum Points')
   end
 
   def test_subtract
     a = Vec3D.new(3, 5, 0)
     b = Vec3D.new(6, 7, 1)
     c = Vec3D.new(-3, -2, -1)
-    assert_equal(a - b, c, 'Failed to subtract vectors')
+    assert_equal(a - b, c, 'Failed to subtract Points')
   end
 
   def test_multiply
@@ -333,7 +350,7 @@ class VecmathTest < Minitest::Test
     b = 2
     c = a * b
     d = Vec3D.new(6, 10, 2)
-    assert_equal(c, d, 'Failed to multiply vector by scalar')
+    assert_equal(c, d, 'Failed to multiply Point by scalar')
   end
 
   def test_divide
@@ -341,7 +358,7 @@ class VecmathTest < Minitest::Test
     b = 2
     c = Vec3D.new(1.5, 2.5, 2)
     d = a / b
-    assert_equal(c, d, 'Failed to divide vector by scalar')
+    assert_equal(c, d, 'Failed to divide Point by scalar')
   end
 
   def test_random
@@ -358,31 +375,31 @@ class VecmathTest < Minitest::Test
 
   def test_mag
     a = Vec3D.new(-3, -4)
-    assert_equal(a.mag, 5, 'Failed to return magnitude of vector')
+    assert_equal(a.mag, 5, 'Failed to return magnitude of Point')
   end
 
   def test_mag_variant
     a = Vec3D.new(3.0, 2)
     b = Math.sqrt(3.0**2 + 2**2)
-    assert_in_epsilon(a.mag, b, 0.001, 'Failed to return magnitude of vector')
+    assert_in_epsilon(a.mag, b, 0.001, 'Failed to return magnitude of Point')
   end
 
   def test_mag_zero_one
     a = Vec3D.new(-1, 0)
-    assert_equal(a.mag, 1, 'Failed to return magnitude of vector')
+    assert_equal(a.mag, 1, 'Failed to return magnitude of Point')
   end
 
   def test_dist
     a = Vec3D.new(3, 5, 2)
     b = Vec3D.new(6, 7, 1)
-    message = 'Failed to return distance between two vectors'
+    message = 'Failed to return distance between two Points'
     assert_equal(a.dist(b), Math.sqrt(3.0**2 + 2**2 + 1), message)
   end
 
   def test_dist_squared
     a = Vec3D.new(3, 5, 2)
     b = Vec3D.new(6, 7, 1)
-    message = 'Failed to return distance squared between two vectors'
+    message = 'Failed to return distance squared between two Points'
     assert_equal(a.dist_squared(b), 3.0**2 + 2**2 + 1, message)
   end
 
@@ -406,17 +423,17 @@ class VecmathTest < Minitest::Test
 
   def test_set_mag
     a = Vec3D.new(1, 1)
-    assert_equal(a.set_mag(Math.sqrt(32)), Vec3D.new(4, 4), 'Failed to set_mag vector')
+    assert_equal(a.set_mag(Math.sqrt(32)), Vec3D.new(4, 4), 'Failed to set_mag Point')
   end
 
   def test_set_mag_block
     a = Vec3D.new(1, 1)
-    assert_equal(a.set_mag(Math.sqrt(32)) { true }, Vec3D.new(4, 4), 'Failed to set_mag_block true vector')
+    assert_equal(a.set_mag(Math.sqrt(32)) { true }, Vec3D.new(4, 4), 'Failed to set_mag_block true Point')
   end
 
   def test_set_mag_block_false
     a = Vec3D.new(1, 1)
-    assert_equal(a.set_mag(Math.sqrt(32)) { false }, Vec3D.new(1, 1), 'Failed to set_mag_block true vector')
+    assert_equal(a.set_mag(Math.sqrt(32)) { false }, Vec3D.new(1, 1), 'Failed to set_mag_block true Point')
   end
 
   def test_plus_assign
@@ -429,13 +446,13 @@ class VecmathTest < Minitest::Test
   def test_normalize
     a = Vec3D.new(3, 5)
     b = a.normalize
-    assert_in_epsilon(b.mag, 1, 0.001, 'Failed to return a normalized vector')
+    assert_in_epsilon(b.mag, 1, 0.001, 'Failed to return a normalized Point')
   end
 
   def test_normalize!
     a = Vec3D.new(3, 5)
     a.normalize!
-    assert_in_epsilon(a.mag, 1, 0.001, 'Failed to return a normalized! vector')
+    assert_in_epsilon(a.mag, 1, 0.001, 'Failed to return a normalized! Point')
   end
 
   def test_inspect

--- a/test/vecmath_spec_test.rb
+++ b/test/vecmath_spec_test.rb
@@ -9,6 +9,10 @@ Dir.chdir(File.dirname(__FILE__))
 
 class VecmathTest < Minitest::Test
 
+  # duck for Vec2D constructor
+  Vector = Struct.new(:x, :y)
+    # duck for Vec3D constructor
+  Vector3 = Struct.new(:x, :y, :z)
 
   def setup
 
@@ -31,6 +35,18 @@ class VecmathTest < Minitest::Test
     a = Vec2D.new(x, y)
     b = a.copy
     assert_equal(a.to_a, b.to_a, 'Failed deep copy')
+  end
+
+  def test_constructor_float
+    val = Vector.new(1.0, 8.0) # duck type
+    expected = Vec2D.new(val)
+    assert_equal(expected, Vec2D.new(1.0, 8.0), 'Failed duck type constructor floats')
+  end
+
+  def test_constructor_fixnum
+    val = Vector.new(1, 8) # duck type fixnum
+    expected = Vec2D.new(val)
+    assert_equal(expected, Vec2D.new(1.0, 8.0), 'Failed duck type constructor fixnum')
   end
 
   def test_copy_not_equals
@@ -257,6 +273,18 @@ class VecmathTest < Minitest::Test
     x, y, z = 1.0000001, 1.01, 0.0
     a = Vec3D.new(x, y)
     assert_equal(a.to_a, [x, y, z], 'Failed to return Vec3D as and Array')
+  end
+
+  def test_constructor_float
+    val = Vector3.new(1.0, 8.0, 7.0) # duck type
+    expected = Vec3D.new(val)
+    assert_equal(expected, Vec3D.new(1.0, 8.0, 7.0), 'Failed duck type constructor floats')
+  end
+
+  def test_constructor_fixnum
+    val = Vector3.new(1, 8, 7) # duck type fixnum
+    expected = Vec3D.new(val)
+    assert_equal(expected, Vec3D.new(1.0, 8.0, 7.0), 'Failed duck type constructor fixnum')
   end
 
   def test_not_equals

--- a/test/vecmath_spec_test.rb
+++ b/test/vecmath_spec_test.rb
@@ -24,7 +24,7 @@ class VecmathTest < Minitest::Test
   def test_equals
     x, y = 1.0000001, 1.01
     a = Vec2D.new(x, y)
-    assert_equal(a.to_a, [x, y], 'Failed to return Vec2D as and Array')
+    assert_equal(a.to_a, [x, y], 'Failed to return Vec2D as an Array')
   end
 
   def test_not_equals
@@ -150,7 +150,7 @@ class VecmathTest < Minitest::Test
   def test_dist
     a = Vec2D.new(3, 5)
     b = Vec2D.new(6, 7)
-    assert_in_epsilon(a.dist(b), Math.sqrt(3.0**2 + 2**2), 'Failed to return distance between two vectors')
+    assert_in_epsilon(a.dist(b), Math.sqrt(3.0**2 + 2**2), 0.001, 'Failed to return distance between two vectors')
   end
 
   def test_lerp
@@ -235,7 +235,7 @@ class VecmathTest < Minitest::Test
     x = 10
     b = Vec2D.new
     b[:x] = x
-    assert_equal(a, Vec2D.new(-10, 20), 'Failed to hash assign')
+    assert_equal(b, Vec2D.new(x, 0), 'Failed to hash assign')
   end
 
   def test_inspect
@@ -279,45 +279,45 @@ class VecmathTest < Minitest::Test
     assert((a - b).cross(b - c).zero?, 'Failed collinearity test using 2D vector cross product')
   end
 
-  def test_equals
+  def test_equals3
     x, y, z = 1.0000001, 1.01, 0.0
     a = Vec3D.new(x, y)
-    assert_equal(a.to_a, [x, y, z], 'Failed to return Vec3D as and Array')
+    assert_equal(a.to_a, [x, y, z], 'Failed to return Vec3D as an Array')
   end
 
-  def test_constructor_float
+  def test_constructor_float3
     val = Point3.new(1.0, 8.0, 7.0) # duck type
     expected = Vec3D.new(val)
     assert_equal(expected, Vec3D.new(1.0, 8.0, 7.0), 'Failed duck type constructor floats')
   end
 
-  def test_constructor_fixnum
+  def test_constructor_fixnum3
     val = Point3.new(1, 8, 7) # duck type fixnum
     expected = Vec3D.new(val)
     assert_equal(expected, Vec3D.new(1.0, 8.0, 7.0), 'Failed duck type constructor fixnum')
   end
 
-  def test_failed_duck_type
+  def test_failed_duck_type3
     val = Pointless3.new(1.0, 8.0, 7.0) # non duck type
     assert_raises TypeError do
       Vec3D.new(val)
     end
   end
 
-  def test_not_equals
+  def test_not_equals3
     a = Vec3D.new(3, 5, 1)
     b = Vec3D.new(6, 7, 1)
     refute_equal(a, b, 'Failed equals false')
   end
 
-  def test_copy_equals
+  def test_copy_equals3
     x, y, z = 1.0000001, 1.01, 1
     a = Vec3D.new(x, y, z)
     b = a.copy
     assert_equal(a.to_a, b.to_a, 'Failed deep copy')
   end
 
-  def test_copy_not_equals
+  def test_copy_not_equals3
     x, y, z = 1.0000001, 1.01, 6.0
     a = Vec3D.new(x, y, z)
     b = a.copy
@@ -325,27 +325,27 @@ class VecmathTest < Minitest::Test
     refute_equal(a.to_a, b.to_a, 'Failed deep copy')
   end
 
-  def test_equals_when_close
+  def test_equals_when_close3
     a = Vec3D.new(3.0000000, 5.00000, 2)
     b = Vec3D.new(3.0000000, 5.000001, 2)
     assert_equal(a, b, 'Failed to return equal when v. close')
   end
 
-  def test_sum
+  def test_sum3
     a = Vec3D.new(3, 5, 1)
     b = Vec3D.new(6, 7, 1)
     c = Vec3D.new(9, 12, 2)
     assert_equal(a + b, c, 'Failed to sum vectors')
   end
 
-  def test_subtract
+  def test_subtract3
     a = Vec3D.new(3, 5, 0)
     b = Vec3D.new(6, 7, 1)
     c = Vec3D.new(-3, -2, -1)
     assert_equal(a - b, c, 'Failed to subtract vectors')
   end
 
-  def test_multiply
+  def test_multiply3
     a = Vec3D.new(3, 5, 1)
     b = 2
     c = a * b
@@ -353,7 +353,7 @@ class VecmathTest < Minitest::Test
     assert_equal(c, d, 'Failed to multiply vector by scalar')
   end
 
-  def test_divide
+  def test_divide3
     a = Vec3D.new(3, 5, 4)
     b = 2
     c = Vec3D.new(1.5, 2.5, 2)
@@ -361,112 +361,112 @@ class VecmathTest < Minitest::Test
     assert_equal(c, d, 'Failed to divide vector by scalar')
   end
 
-  def test_random
+  def test_random3
     a = Vec3D.random
     assert a.kind_of? Vec3D
     assert_in_epsilon(a.mag, 1.0)
   end
 
-  def test_assign_value
+  def test_assign_value3
     a = Vec3D.new(3, 5)
     a.x=23
     assert_equal(a.x, 23, 'Failed to assign x value')
   end
 
-  def test_mag
+  def test_mag3
     a = Vec3D.new(-3, -4)
     assert_equal(a.mag, 5, 'Failed to return magnitude of vector')
   end
 
-  def test_mag_variant
+  def test_mag_variant3
     a = Vec3D.new(3.0, 2)
     b = Math.sqrt(3.0**2 + 2**2)
     assert_in_epsilon(a.mag, b, 0.001, 'Failed to return magnitude of vector')
   end
 
-  def test_mag_zero_one
+  def test_mag_zero_one3
     a = Vec3D.new(-1, 0)
     assert_equal(a.mag, 1, 'Failed to return magnitude of vector')
   end
 
-  def test_dist
+  def test_dist3
     a = Vec3D.new(3, 5, 2)
     b = Vec3D.new(6, 7, 1)
     message = 'Failed to return distance between two vectors'
     assert_equal(a.dist(b), Math.sqrt(3.0**2 + 2**2 + 1), message)
   end
 
-  def test_dist_squared
+  def test_dist_squared3
     a = Vec3D.new(3, 5, 2)
     b = Vec3D.new(6, 7, 1)
     message = 'Failed to return distance squared between two vectors'
     assert_equal(a.dist_squared(b), 3.0**2 + 2**2 + 1, message)
   end
 
-  def test_dot
+  def test_dot3
     a = Vec3D.new(10, 20, 0)
     b = Vec3D.new(60, 80, 0)
     assert_in_epsilon(a.dot(b), 2200.0, 0.001, 'Failed to dot product')
   end
 
-  def test_self_dot
+  def test_self_dot3
     a = Vec3D.new(10, 20, 4)
     assert_in_epsilon(a.dot(a), 516.0, 0.001, 'Failed to self dot product')
   end
 
-  def test_cross
+  def test_cross3
     a = Vec3D.new(3, 5, 2)
     b = Vec3D.new(6, 7, 1)
     c = Vec3D.new(-9.0, 9.0, -9.0)
     assert_equal(a.cross(b), c, 'Failed cross product')
   end
 
-  def test_set_mag
+  def test_set_mag3
     a = Vec3D.new(1, 1)
     assert_equal(a.set_mag(Math.sqrt(32)), Vec3D.new(4, 4), 'Failed to set_mag vector')
   end
 
-  def test_set_mag_block
+  def test_set_mag_block3
     a = Vec3D.new(1, 1)
     assert_equal(a.set_mag(Math.sqrt(32)) { true }, Vec3D.new(4, 4), 'Failed to set_mag_block true vector')
   end
 
-  def test_set_mag_block_false
+  def test_set_mag_block_false3
     a = Vec3D.new(1, 1)
     assert_equal(a.set_mag(Math.sqrt(32)) { false }, Vec3D.new(1, 1), 'Failed to set_mag_block true vector')
   end
 
-  def test_plus_assign
+  def test_plus_assign3
     a = Vec3D.new(3, 5)
     b = Vec3D.new(6, 7)
     a += b
     assert_equal(a, Vec3D.new(9, 12), 'Failed to += assign')
   end
 
-  def test_normalize
+  def test_normalize3
     a = Vec3D.new(3, 5)
     b = a.normalize
     assert_in_epsilon(b.mag, 1, 0.001, 'Failed to return a normalized vector')
   end
 
-  def test_normalize!
+  def test_normalize3!
     a = Vec3D.new(3, 5)
     a.normalize!
     assert_in_epsilon(a.mag, 1, 0.001, 'Failed to return a normalized! vector')
   end
 
-  def test_inspect
+  def test_inspect3
     a = Vec3D.new(3, 2.000000000000001, 1)
     assert_equal(a.inspect, 'Vec3D(x = 3.0000, y = 2.0000, z = 1.0000)')
   end
 
-  def test_array_reduce
+  def test_array_reduce3
     array = [Vec3D.new(1, 2), Vec3D.new(10, 2), Vec3D.new(1, 2)]
     sum = array.reduce(Vec3D.new) { |c, d| c + d }
     assert_equal(sum, Vec3D.new(12, 6))
   end
 
-  def test_array_zip
+  def test_array_zip3
     one = [Vec3D.new(1, 2), Vec3D.new(10, 2), Vec3D.new(1, 2)]
     two = [Vec3D.new(1, 2), Vec3D.new(10, 2), Vec3D.new(1, 2)]
     zipped = one.zip(two).flatten
@@ -474,30 +474,30 @@ class VecmathTest < Minitest::Test
     assert_equal(zipped, expected)
   end
 
-  def test_eql?
+  def test_eql3?
     a = Vec3D.new(3.0, 5.0, 0)
     b = Vec3D.new(3.0, 5.0, 0)
     assert(a.eql?(b))
   end
 
-  def test_not_eql?
+  def test_not_eql3?
     a = Vec3D.new(3.0, 5.0, 0)
     b = Vec3D.new(3.0, 5.000001, 0)
     refute(a.eql?(b))
   end
 
-  def test_equal?
+  def test_equal3?
     a = Vec3D.new(3.0, 5.0, 0)
     assert(a.equal?(a))
   end
 
-  def test_not_equal?
+  def test_not_equal3?
     a = Vec3D.new(3.0, 5.0, 0)
     b = Vec3D.new(3.0, 5.0, 0)
     refute(a.equal?(b))
   end
 
-  def test_hash_key
+  def test_hash_key3
     x, y, z = 10, 20, 50
     b = Vec3D.new(x, y, z)
     assert_equal(b[:x], x, 'Failed hash key access')
@@ -505,7 +505,7 @@ class VecmathTest < Minitest::Test
     assert_equal(b[:z], z, 'Failed hash key access')
   end
 
-  def test_hash_set
+  def test_hash_set3
     x = 10
     b = Vec3D.new
     b[:x] = x


### PR DESCRIPTION
Proposal: Allow duck-types to be used in Vec3D and Vec2D constructors, initializing objects need only have methods `:x` and `:y` that return fixnum or float. Hence a Vec2D object can be used to initialize a Vec3D object where `z==0`